### PR TITLE
修复大文本转换与应用流程，优化处理性能

### DIFF
--- a/OpenCCman.xcodeproj/project.pbxproj
+++ b/OpenCCman.xcodeproj/project.pbxproj
@@ -7,8 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CC0912202600000000000001 /* ChineseConversionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0912202600000000000002 /* ChineseConversionService.swift */; };
 		0920E96C2E3F4D3C003C9715 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 0920E96B2E3F4D3C003C9715 /* InfoPlist.xcstrings */; };
 		095E17452E40746F0051BBB7 /* ServicesMenu.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 095E17442E40746F0051BBB7 /* ServicesMenu.xcstrings */; };
+		CC0912202600000000000011 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = CC0912202600000000000012 /* PrivacyInfo.xcprivacy */; };
 		09DBEC4F2E3BC32F00DD9C5B /* ShortcutSettingsScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DBEC4E2E3BC32F00DD9C5B /* ShortcutSettingsScene.swift */; };
 		09DBEC522E3BC4BC00DD9C5B /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 09DBEC512E3BC4BC00DD9C5B /* KeyboardShortcuts */; };
 		09DBEC552E3BC69000DD9C5B /* GlobalShortcutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DBEC532E3BC69000DD9C5B /* GlobalShortcutService.swift */; };
@@ -71,8 +73,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		CC0912202600000000000002 /* ChineseConversionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChineseConversionService.swift; sourceTree = "<group>"; };
 		0920E96B2E3F4D3C003C9715 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		095E17442E40746F0051BBB7 /* ServicesMenu.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = ServicesMenu.xcstrings; sourceTree = "<group>"; };
+		CC0912202600000000000012 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		09DBEC4E2E3BC32F00DD9C5B /* ShortcutSettingsScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutSettingsScene.swift; sourceTree = "<group>"; };
 		09DBEC532E3BC69000DD9C5B /* GlobalShortcutService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalShortcutService.swift; sourceTree = "<group>"; };
 		BE2C6D402B2D7ED000FC4112 /* ViewExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewExtensions.swift; sourceTree = "<group>"; };
@@ -153,6 +157,7 @@
 		09DBEC542E3BC69000DD9C5B /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				CC0912202600000000000002 /* ChineseConversionService.swift */,
 				09DBEC532E3BC69000DD9C5B /* GlobalShortcutService.swift */,
 			);
 			path = Services;
@@ -266,6 +271,7 @@
 				BE3AEC9D2B2EF2D400820673 /* IAPManager.swift */,
 				BEA770EA2B2C904A00AFA2F0 /* Assets.xcassets */,
 				BEA770EC2B2C904A00AFA2F0 /* OpenCCman.entitlements */,
+				CC0912202600000000000012 /* PrivacyInfo.xcprivacy */,
 				0920E96B2E3F4D3C003C9715 /* InfoPlist.xcstrings */,
 				095E17442E40746F0051BBB7 /* ServicesMenu.xcstrings */,
 				BE727E3A2B2E00D000C63DB2 /* Localizable.strings */,
@@ -380,6 +386,7 @@
 			files = (
 				BEA770EF2B2C904A00AFA2F0 /* Preview Assets.xcassets in Resources */,
 				095E17452E40746F0051BBB7 /* ServicesMenu.xcstrings in Resources */,
+				CC0912202600000000000011 /* PrivacyInfo.xcprivacy in Resources */,
 				BE727E382B2E00D000C63DB2 /* Localizable.strings in Resources */,
 				0920E96C2E3F4D3C003C9715 /* InfoPlist.xcstrings in Resources */,
 				BEA770EB2B2C904A00AFA2F0 /* Assets.xcassets in Resources */,
@@ -393,6 +400,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CC0912202600000000000001 /* ChineseConversionService.swift in Sources */,
 				BE2C6D522B2D7ED000FC4112 /* ImageExtensions.swift in Sources */,
 				BEA770E92B2C904900AFA2F0 /* HomeScene.swift in Sources */,
 				BE3AECB52B2EF6F700820673 /* CardReflectionView.swift in Sources */,

--- a/OpenCCman/AppDelegate.swift
+++ b/OpenCCman/AppDelegate.swift
@@ -26,8 +26,18 @@
   import SwiftyUserDefaults
   import KeyboardShortcuts
 
-  class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
+  @MainActor
+  class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, ObservableObject {
     private var statusItem: NSStatusItem?
+    private static let readyWindows = NSHashTable<NSWindow>.weakObjects()
+    private static var pendingWindowNotification: PendingWindowNotification?
+
+    private struct PendingWindowNotification {
+      let name: Notification.Name
+      let userInfo: [AnyHashable: Any]?
+      weak var window: NSWindow?
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
       // Register the text conversion service
       NSApp.servicesProvider = TextConversionService.shared
@@ -52,23 +62,24 @@
       // Add a menu item for testing the hotkey functionality
       if let mainMenu = NSApp.mainMenu {
         let testMenu = NSMenu(title: "Test")
+        testMenu.delegate = self
         let testMenuItem = NSMenuItem(title: "Test", action: nil, keyEquivalent: "")
         testMenuItem.submenu = testMenu
 
         let convertSelectedTextItem = NSMenuItem(
           title: "Convert Selected Text",
           action: #selector(convertSelectedText),
-          keyEquivalent: "t"
+          keyEquivalent: ""
         )
-        convertSelectedTextItem.keyEquivalentModifierMask = [.command, .option]
+        convertSelectedTextItem.setShortcut(for: .convertSelectedText)
         convertSelectedTextItem.target = self
 
         let openSelectedTextItem = NSMenuItem(
           title: "Open Selected Text",
           action: #selector(openSelectedText),
-          keyEquivalent: "r"
+          keyEquivalent: ""
         )
-        openSelectedTextItem.keyEquivalentModifierMask = [.command, .option]
+        openSelectedTextItem.setShortcut(for: .openSelectedText)
         openSelectedTextItem.target = self
 
         testMenu.addItem(convertSelectedTextItem)
@@ -85,10 +96,54 @@
       GlobalShortcutService.shared.openSelectedText()
     }
 
+    func applicationDidBecomeActive(_ notification: Notification) {
+      GlobalShortcutService.shared.checkAccessibilityPermission()
+    }
+
+    func menuWillOpen(_ menu: NSMenu) {
+      KeyboardShortcuts.isEnabled = false
+    }
+
+    func menuDidClose(_ menu: NSMenu) {
+      KeyboardShortcuts.isEnabled = GlobalShortcutService.shared.isEnabled
+    }
+
+    @discardableResult
+    static func activateMainWindow() -> NSWindow? {
+      let keyWindow = NSApp.keyWindow.flatMap { $0.canBecomeMain ? $0 : nil }
+      let window = keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first(where: { $0.canBecomeMain })
+      window?.makeKeyAndOrderFront(nil)
+      NSApp.activate(ignoringOtherApps: true)
+      return window
+    }
+
+    static func postWindowNotification(name: Notification.Name, userInfo: [AnyHashable: Any]? = nil) {
+      let window = activateMainWindow()
+      // Only the latest request is retained while SwiftUI creates and binds its window.
+      pendingWindowNotification = nil
+      guard let window, readyWindows.contains(window) else {
+        pendingWindowNotification = PendingWindowNotification(name: name, userInfo: userInfo, window: window)
+        return
+      }
+      NotificationCenter.default.post(name: name, object: window, userInfo: userInfo)
+    }
+
+    static func registerReadyWindow(_ window: NSWindow) {
+      // Let Root's window state and notification subscriptions settle before delivery.
+      DispatchQueue.main.async { [weak window] in
+        guard let window else { return }
+        readyWindows.add(window)
+        guard let pending = pendingWindowNotification,
+              pending.window == nil || pending.window === window else { return }
+        pendingWindowNotification = nil
+        NotificationCenter.default.post(name: pending.name, object: window, userInfo: pending.userInfo)
+      }
+    }
+
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
       // Bring the app to front when clicked in dock
       if !flag {
-        NSApp.activate(ignoringOtherApps: true)
+        Self.activateMainWindow()
       }
       return true
     }
@@ -99,8 +154,10 @@
       updateStatusBarVisibility()
     }
 
-    @objc private func userDefaultsDidChange() {
-      updateStatusBarVisibility()
+    @objc nonisolated private func userDefaultsDidChange() {
+      DispatchQueue.main.async { [weak self] in
+        self?.updateStatusBarVisibility()
+      }
     }
 
     private func updateStatusBarVisibility() {
@@ -136,6 +193,7 @@
 
     private func createStatusMenu() -> NSMenu {
       let menu = NSMenu()
+      menu.delegate = self
 
       // 应用名称和版本
       let titleItem = NSMenuItem(title: "OpenCCman \(Bundle.main.appVersion)", action: nil, keyEquivalent: "")
@@ -209,18 +267,15 @@
 
     @objc private func convertTextFromStatusBar() {
       // 激活应用并发送转换通知
-      NSApp.activate(ignoringOtherApps: true)
-      NotificationCenter.default.post(name: Notification.Name("ConvertTextFromMenu"), object: nil)
+      Self.postWindowNotification(name: Notification.Name("ConvertTextFromMenu"))
     }
 
     @objc private func openSettingsFromStatusBar() {
-      NSApp.activate(ignoringOtherApps: true)
-      NotificationCenter.default.post(name: Notification.Name("OpenSettingsFromMenu"), object: nil)
+      Self.postWindowNotification(name: Notification.Name("OpenSettingsFromMenu"))
     }
 
     @objc private func openHelpFromStatusBar() {
-      NSApp.activate(ignoringOtherApps: true)
-      NotificationCenter.default.post(name: Notification.Name("OpenHelpFromMenu"), object: nil)
+      Self.postWindowNotification(name: Notification.Name("OpenHelpFromMenu"))
     }
 
     @objc private func quitApp() {
@@ -270,12 +325,14 @@
           }
 
           do {
-              let converter = try ChineseConverter(options: options)
-              let convertedText = converter.convert(string)
+              let convertedText = try ChineseConversionService.convertSynchronously(string, options: options)
 
               // Clear the pasteboard and set the converted text
               pboard.clearContents()
-              pboard.setString(convertedText, forType: .string)
+              guard pboard.setString(convertedText, forType: .string) else {
+                  error.pointee = "Could not write converted text to pasteboard" as NSString
+                  return
+              }
 
               // Bring the app to front and populate the input field
               DispatchQueue.main.async {
@@ -303,14 +360,9 @@
 
       // MARK: - App Integration
 
-      private func bringAppToFrontAndSetText(originalText: String, convertedText: String) {
-          // Activate the app
-          NSApp.activate(ignoringOtherApps: true)
-
-          // Post notification to update the UI
-          NotificationCenter.default.post(
+      @MainActor private func bringAppToFrontAndSetText(originalText: String, convertedText: String) {
+          AppDelegate.postWindowNotification(
               name: .textConversionServiceDidReceiveText,
-              object: nil,
               userInfo: [
                   "originalText": originalText,
                   "convertedText": convertedText
@@ -318,14 +370,9 @@
           )
       }
 
-      private func bringAppToFrontAndSetTextOnly(originalText: String) {
-          // Activate the app
-          NSApp.activate(ignoringOtherApps: true)
-
-          // Post notification to update the UI with just the original text
-          NotificationCenter.default.post(
+      @MainActor private func bringAppToFrontAndSetTextOnly(originalText: String) {
+          AppDelegate.postWindowNotification(
               name: .textServiceDidReceiveText,
-              object: nil,
               userInfo: [
                   "originalText": originalText
               ]

--- a/OpenCCman/Helpers/ReviewHandler.swift
+++ b/OpenCCman/Helpers/ReviewHandler.swift
@@ -5,7 +5,17 @@ import SwiftUI
 class ReviewHandler {
   static func requestReview() {
     DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2.0) {
-      SKStoreReviewController.requestReview()
+      #if os(iOS)
+        let activeScenes = UIApplication.shared.connectedScenes
+          .compactMap { $0 as? UIWindowScene }
+          .filter { $0.activationState == .foregroundActive }
+        guard let scene = activeScenes.first(where: { $0.windows.contains(where: \.isKeyWindow) })
+          ?? activeScenes.first else { return }
+        SKStoreReviewController.requestReview(in: scene)
+      #elseif os(macOS)
+        guard NSApplication.shared.isActive else { return }
+        SKStoreReviewController.requestReview()
+      #endif
     }
   }
 }

--- a/OpenCCman/IAPManager.swift
+++ b/OpenCCman/IAPManager.swift
@@ -41,7 +41,7 @@ enum ProFeature: String, CaseIterable, Identifiable {
   var id: ProFeature { self }
 }
 
-final class IAPManager {
+final class IAPManager: NSObject, PurchasesDelegate {
   enum Sku: String {
     case ios_openccman_pro_lifetime_3
   }
@@ -56,22 +56,26 @@ final class IAPManager {
 
   static let shared = IAPManager()
 
-  private init() {}
-
-  func configure() {
-    Purchases.configure(withAPIKey: "appl_EJkSanbpeFhoNJsZaUbpIZPduCi")
-    Purchases.proxyURL = URL(string: "https://api.rc-backup.com/")!
+  private override init() {
+    super.init()
   }
 
-  func checkProLifetime(completion: @escaping (Bool) -> Void) {
+  func configure() {
+    guard Purchases.isConfigured == false else { return }
+
+    Purchases.proxyURL = URL(string: "https://api.rc-backup.com/")!
+    Purchases.configure(withAPIKey: "appl_EJkSanbpeFhoNJsZaUbpIZPduCi")
+    Purchases.shared.delegate = self
+  }
+
+  func checkProLifetime(completion: @escaping (Bool?) -> Void) {
     Purchases.shared.getCustomerInfo { customerInfo, _ in
-      if let infos = customerInfo?.entitlements.active,
-         let _ = infos[IAPManager.Permission.pro_lifetime.rawValue] {
-        completion(true)
-      } else {
-        completion(false)
-      }
+      completion(customerInfo.map { $0.entitlements.active[Permission.pro_lifetime.rawValue] != nil })
     }
-    Purchases.shared.restorePurchases()
+  }
+
+  func purchases(_ purchases: Purchases, receivedUpdated customerInfo: CustomerInfo) {
+    let isPro = customerInfo.entitlements.active[Permission.pro_lifetime.rawValue] != nil
+    UserDefaults.standard.set(isPro, forKey: UserDefaultsKeys.isPro.rawValue)
   }
 }

--- a/OpenCCman/Model/OpenSourceModel.swift
+++ b/OpenCCman/Model/OpenSourceModel.swift
@@ -268,4 +268,61 @@ let allOpenSourceModels =
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
     """),
+    OpenSourceModel(name: "ColorVector", link: "https://github.com/Lakr233/ColorVector", licence: """
+    MIT License
+
+    Copyright (c) 2024 Lakr
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+    """),
+    OpenSourceModel(name: "MSDisplayLink", link: "https://github.com/Lakr233/MSDisplayLink", licence: """
+    MIT License
+
+    Copyright (c) 2024 Lakr Aream
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+    """),
+    OpenSourceModel(name: "KeyboardShortcuts", link: "https://github.com/sindresorhus/KeyboardShortcuts", licence: """
+    MIT License
+
+    Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    """),
   ]

--- a/OpenCCman/Model/TestNumbersPerDayManager.swift
+++ b/OpenCCman/Model/TestNumbersPerDayManager.swift
@@ -1,23 +1,27 @@
 import Foundation
 
 enum TestNumbersPerDayManager {
+  private static let dayFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.timeZone = .autoupdatingCurrent
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter
+  }()
+
   static func add() {
     guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.isPro.rawValue) == false else { return }
 
-    let today = Date().string(withFormat: "yyyy-MM-dd")
-
-    if let count = appDefaults[\.testNumbersPerDay][today] {
-      appDefaults[\.testNumbersPerDay][today] = count + 1
-    } else {
-      appDefaults[\.testNumbersPerDay] = [:]
-      appDefaults[\.testNumbersPerDay][today] = 1
-    }
+    let today = dayFormatter.string(from: Date())
+    let count = appDefaults[\.testNumbersPerDay][today] ?? 0
+    appDefaults[\.testNumbersPerDay] = [today: count + 1]
   }
 
   static var isToMax: Bool {
     guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.isPro.rawValue) == false else { return false }
 
-    let today = Date().string(withFormat: "yyyy-MM-dd")
+    let today = dayFormatter.string(from: Date())
 
     if let count = appDefaults[\.testNumbersPerDay][today] {
       return count >= FreeFeature.maxTestNumber

--- a/OpenCCman/OpenCCman.entitlements
+++ b/OpenCCman/OpenCCman.entitlements
@@ -8,7 +8,5 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<key>com.apple.security.automation.apple-events</key>
-	<true/>
 </dict>
 </plist>

--- a/OpenCCman/OpenCCmanApp.swift
+++ b/OpenCCman/OpenCCmanApp.swift
@@ -43,7 +43,7 @@ struct OpenCCmanApp: App {
     .commands {
       CommandGroup(after: .textEditing) {
         Button("Convert".localizedStringKey, systemImage: "arrow.trianglehead.2.counterclockwise") {
-          NotificationCenter.default.post(name: Notification.Name("ConvertTextFromMenu"), object: nil)
+          NotificationCenter.default.post(name: Notification.Name("ConvertTextFromMenu"), object: NSApp.keyWindow)
         }
         .keyboardShortcut("t")
       }
@@ -56,6 +56,7 @@ struct OpenCCmanApp: App {
   func checkPro() {
     if Date().yesterday.unixTimestamp >= lastCheckProDate {
       IAPManager.shared.checkProLifetime { isPro in
+        guard let isPro else { return }
         self.isPro = isPro
         lastCheckProDate = Date().unixTimestamp
       }

--- a/OpenCCman/PrivacyInfo.xcprivacy
+++ b/OpenCCman/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/OpenCCman/Scene/HomeScene.swift
+++ b/OpenCCman/Scene/HomeScene.swift
@@ -7,7 +7,7 @@ struct HomeScene: View {
   @EnvironmentObject var navigator: Navigator
 
   @AppStorage(UserDefaultsKeys.isPro.rawValue) var isPro: Bool = false
-  @ObservedObject var viewModel = HomeViewModel()
+  @EnvironmentObject private var viewModel: HomeViewModel
 
   var body: some View {
     ZStack(alignment: .top) {
@@ -29,6 +29,12 @@ struct HomeScene: View {
     }
     .frame(minWidth: 300)
     .overlay(ProAlertView(showingProAlert: $viewModel.showingProAlert))
+    .alert(isPresented: Binding(
+      get: { viewModel.error != nil },
+      set: { if !$0 { viewModel.error = nil } }
+    )) {
+      Alert(title: Text("Error"), message: Text(viewModel.error?.localizedDescription ?? ""))
+    }
   }
 
   var navi: some View {
@@ -123,6 +129,7 @@ struct HomeScene: View {
           })
           .softButtonStyle(RoundedRectangle(cornerRadius: 20), padding: 10, mainColor: Color.accentColor, textColor: Color.Neumorphic.main)
           .keyboardShortcut("t")
+          .disabled(viewModel.isLoading || viewModel.inputText.isEmpty)
         }
         TextEditor(text: $viewModel.inputText)
           .clearTextEdtorStyle()
@@ -159,15 +166,18 @@ struct HomeScene: View {
                 }
               }
           }
-          Text("\(viewModel.localProgressPercent)%")
-            .modify {
-              if #available(iOS 15, macOS 12,*) {
-                $0.monospacedDigit()
+          if !viewModel.isLoading {
+            Text("\(viewModel.localProgressPercent)%")
+              .modify {
+                if #available(iOS 15, macOS 12, *) {
+                  $0.monospacedDigit()
+                }
               }
-            }
+          }
         }
-        Text(viewModel.resultText)
-          .textSelectable()
+        TextEditor(text: .constant(viewModel.resultText))
+          .clearTextEdtorStyle(isEditable: false)
+          .accessibilityLabel(Text("Result"))
           .frame(maxWidth: .infinity, minHeight: 200, maxHeight: 300, alignment: .topLeading)
           .padding(Constant.padding)
           .background(
@@ -189,5 +199,8 @@ struct HomeScene: View {
 }
 
 #Preview {
-  HomeScene()
+  Router {
+    HomeScene()
+      .environmentObject(HomeViewModel())
+  }
 }

--- a/OpenCCman/Scene/HomeViewModel.swift
+++ b/OpenCCman/Scene/HomeViewModel.swift
@@ -12,6 +12,7 @@ import SwiftyUserDefaults
   }
 #endif
 
+@MainActor
 class HomeViewModel: ObservableObject {
   @Published var inputText: String = "鼠标里面的硅二极管坏了，导致光标分辨率降低。"
   @Published var resultText: String = ""
@@ -33,6 +34,15 @@ class HomeViewModel: ObservableObject {
   }
 
   private var cancellables = Set<AnyCancellable>()
+  private var conversionTask: Task<Void, Never>?
+  #if os(macOS)
+    weak var window: NSWindow?
+
+    private func accepts(_ notification: Notification) -> Bool {
+      guard let window else { return false }
+      return window === ((notification.object as? NSWindow) ?? NSApp.keyWindow)
+    }
+  #endif
 
   // MARK: - life cycle
 
@@ -56,11 +66,10 @@ class HomeViewModel: ObservableObject {
         } else {
           options.formUnion(.simplify)
         }
-        print("options:", options)
         return options
       }
-      .assign(to: \.options, on: self)
-      .store(in: &cancellables)
+      .removeDuplicates()
+      .assign(to: &$options)
 
     $targetOptions.dropFirst()
       .sink { targetOptions in
@@ -87,8 +96,11 @@ class HomeViewModel: ObservableObject {
           }
 
           DispatchQueue.main.async {
+            guard self.accepts(notification) else { return }
+            self.cancelConversion()
             self.inputText = originalText
             self.resultText = convertedText
+            self.localProgress = 1.0
           }
         }
         .store(in: &cancellables)
@@ -104,8 +116,11 @@ class HomeViewModel: ObservableObject {
           }
 
           DispatchQueue.main.async {
+            guard self.accepts(notification) else { return }
+            self.cancelConversion()
             self.inputText = originalText
             self.resultText = convertedText
+            self.localProgress = 1.0
           }
         }
         .store(in: &cancellables)
@@ -120,6 +135,8 @@ class HomeViewModel: ObservableObject {
           }
 
           DispatchQueue.main.async {
+            guard self.accepts(notification) else { return }
+            self.cancelConversion()
             self.inputText = originalText
             self.resultText = "" // Clear result text since we're not converting
           }
@@ -128,10 +145,11 @@ class HomeViewModel: ObservableObject {
 
       // Listen for menu convert notifications
       NotificationCenter.default.publisher(for: .convertTextFromMenu)
-        .sink { [weak self] _ in
+        .sink { [weak self] notification in
           guard let self = self else { return }
 
           DispatchQueue.main.async {
+            guard self.accepts(notification) else { return }
             self.translate()
           }
         }
@@ -142,8 +160,9 @@ class HomeViewModel: ObservableObject {
   // MARK: - response methods
 
   func translate() {
+    guard !isLoading, !inputText.isEmpty else { return }
     guard TestNumbersPerDayManager.isToMax == false else {
-      showingProAlert.toggle()
+      showingProAlert = true
       return
     }
 
@@ -151,62 +170,42 @@ class HomeViewModel: ObservableObject {
     isLoading = true
     resultText = ""
     localProgress = 0.0
+    error = nil
 
     let currentInput = inputText
     let currentOptions = options
 
-    // Pre-create converter on background thread once to amortize cost
-    Task(priority: .userInitiated) { [weak self] in
-      guard let self else { return }
+    conversionTask = Task(priority: .userInitiated) { [weak self] in
       do {
-        let converter: ChineseConverter = try await withCheckedThrowingContinuation { continuation in
-          DispatchQueue.global(qos: .userInitiated).async {
-            do {
-              let conv = try ChineseConverter(options: currentOptions)
-              continuation.resume(returning: conv)
-            } catch {
-              continuation.resume(throwing: error)
-            }
-          }
-        }
-
-        let chunks = self.chunked(text: currentInput)
-        let total = max(chunks.count, 1)
-
-        // Convert each chunk sequentially on a background queue and append on main
-        for (index, chunk) in chunks.enumerated() {
-          let convertedChunk: String = await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-              let out = converter.convert(chunk)
-              continuation.resume(returning: out)
-            }
-          }
-
-          await MainActor.run {
-            if self.resultText.isEmpty {
-              self.resultText = convertedChunk
-            } else {
-              self.resultText += "\n" + convertedChunk
-            }
-            self.localProgress = Double(index + 1) / Double(total)
-          }
-        }
-
-        await MainActor.run {
-          TestNumbersPerDayManager.add()
-          self.showReview()
-          self.localProgress = 1.0
-          self.isLoading = false
-        }
+        let result = try await ChineseConversionService.shared.convert(currentInput, options: currentOptions)
+        try Task.checkCancellation()
+        guard let self else { return }
+        self.resultText = result
+        TestNumbersPerDayManager.add()
+        self.showReview()
+        self.localProgress = 1.0
+        self.isLoading = false
+        self.conversionTask = nil
       } catch {
-        await MainActor.run {
-          self.error = error
-          self.isLoading = false
-          self.localProgress = 0.0
-          print(error.localizedDescription)
-        }
+        guard !Task.isCancelled, let self else { return }
+        self.error = error
+        self.isLoading = false
+        self.localProgress = 0.0
+        self.conversionTask = nil
       }
     }
+  }
+
+  func cancelConversion() {
+    conversionTask?.cancel()
+    conversionTask = nil
+    isLoading = false
+    localProgress = 0.0
+    error = nil
+  }
+
+  deinit {
+    conversionTask?.cancel()
   }
 
   // MARK: - Review
@@ -245,49 +244,4 @@ class HomeViewModel: ObservableObject {
     var title: String { rawValue }
   }
 
-  // Chunking helper: split large text by paragraphs first, then by size
-  private func chunked(text: String, maxChunkLength: Int = 4000) -> [String] {
-    guard !text.isEmpty else { return [] }
-
-    // Prefer splitting by double newlines (paragraphs)
-    let paragraphs = text.components(separatedBy: "\n\n").filter { !$0.isEmpty }
-
-    var chunks: [String] = []
-    var current = ""
-
-    func flushCurrent() {
-      if !current.isEmpty { chunks.append(current); current.removeAll(keepingCapacity: true) }
-    }
-
-    if paragraphs.count > 1 {
-      for para in paragraphs {
-        if current.count + para.count + 2 <= maxChunkLength {
-          if current.isEmpty { current = para } else { current += "\n\n" + para }
-        } else if para.count <= maxChunkLength {
-          flushCurrent()
-          current = para
-        } else {
-          // Paragraph itself is too big, hard-split by size
-          var start = para.startIndex
-          while start < para.endIndex {
-            let end = para.index(start, offsetBy: maxChunkLength, limitedBy: para.endIndex) ?? para.endIndex
-            chunks.append(String(para[start ..< end]))
-            start = end
-          }
-          current.removeAll(keepingCapacity: true)
-        }
-      }
-      flushCurrent()
-    } else {
-      // No clear paragraph boundaries, split by size
-      var start = text.startIndex
-      while start < text.endIndex {
-        let end = text.index(start, offsetBy: maxChunkLength, limitedBy: text.endIndex) ?? text.endIndex
-        chunks.append(String(text[start ..< end]))
-        start = end
-      }
-    }
-
-    return chunks
-  }
 }

--- a/OpenCCman/Scene/ProScene.swift
+++ b/OpenCCman/Scene/ProScene.swift
@@ -8,6 +8,7 @@ struct ProScene: View {
   @AppStorage(UserDefaultsKeys.isPro.rawValue) var isPro: Bool = false
   @State var isLoading: Bool = false
   @State var errorMessage: String = ""
+  @State private var errorMessageID = UUID()
   var isPresented: Bool = false
 
   // MARK: - life cycle
@@ -29,6 +30,7 @@ struct ProScene: View {
 
         Button {
           self.isLoading = true
+          self.errorMessage = ""
           Purchases.shared.restorePurchases { customerInfo, error in
             self.isLoading = false
             self.showError(message: error?.localizedDescription)
@@ -143,8 +145,10 @@ struct ProScene: View {
 
         Button {
           self.isLoading = true
-          Purchases.shared.purchase(package: packages[0]) { _, customerInfo, error, _ in
+          self.errorMessage = ""
+          Purchases.shared.purchase(package: package) { _, customerInfo, error, userCancelled in
             self.isLoading = false
+            guard userCancelled == false else { return }
             self.showError(message: error?.localizedDescription)
             self.setEntitlementInfos(customerInfo?.entitlements.all)
           }
@@ -164,21 +168,22 @@ struct ProScene: View {
   // MARK: -
 
   func updateOfferingsAndPermissions() {
-    guard isPro == false else { return }
+    guard isLoading == false else { return }
 
     isLoading = true
+    errorMessage = ""
     let group = DispatchGroup()
     group.enter()
     Purchases.shared.getOfferings { offerings, error in
       self.showError(message: error?.localizedDescription)
+      self.setOfferings(offerings)
       group.leave()
-      self.packages = offerings?.all.flatMap { $0.value.availablePackages } ?? []
     }
     group.enter()
     Purchases.shared.getCustomerInfo { customerInfo, error in
       self.showError(message: error?.localizedDescription)
-      group.leave()
       self.setEntitlementInfos(customerInfo?.entitlements.all)
+      group.leave()
     }
     group.notify(queue: .main) {
       self.isLoading = false
@@ -190,7 +195,7 @@ struct ProScene: View {
     Purchases.shared.getOfferings { offerings, error in
       self.showError(message: error?.localizedDescription)
       self.isLoading = false
-      self.packages = offerings?.all.flatMap { $0.value.availablePackages } ?? []
+      self.setOfferings(offerings)
     }
   }
 
@@ -201,8 +206,10 @@ struct ProScene: View {
   }
 
   func setEntitlementInfos(_ entitlementInfos: [String: RevenueCat.EntitlementInfo]?) {
-    if let entitlementInfos,
-       let pro = entitlementInfos[IAPManager.Permission.pro_lifetime.rawValue],
+    // A failed request is not evidence that the customer lost their entitlement.
+    guard let entitlementInfos else { return }
+
+    if let pro = entitlementInfos[IAPManager.Permission.pro_lifetime.rawValue],
        pro.isActive
     {
       isPro = true
@@ -210,13 +217,22 @@ struct ProScene: View {
       isPro = false
     }
 
-    self.entitlementInfos = entitlementInfos ?? [:]
+    self.entitlementInfos = entitlementInfos
+  }
+
+  func setOfferings(_ offerings: RevenueCat.Offerings?) {
+    guard let offerings else { return }
+    let offering = offerings.current ?? offerings.all[IAPManager.Offering.pro_lifetime.rawValue]
+    self.packages = offering?.availablePackages ?? []
   }
 
   func showError(message: String?) {
     if let message, message.isEmpty == false {
+      let messageID = UUID()
+      errorMessageID = messageID
       errorMessage = message
       DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+        guard self.errorMessageID == messageID else { return }
         self.errorMessage = ""
       }
     }

--- a/OpenCCman/Scene/RootView.swift
+++ b/OpenCCman/Scene/RootView.swift
@@ -1,13 +1,18 @@
 import Neumorphic
 import SwiftUI
 import SwiftUIRouter
-import Combine
+#if os(macOS)
+  import SwiftUIIntrospect
+#endif
 
 struct RootView: View {
   @EnvironmentObject private var navigator: Navigator
+  @StateObject private var viewModel = HomeViewModel()
   @State private var showAd: Bool = false
   @AppStorage(UserDefaultsKeys.isPro.rawValue) var isPro: Bool = false
-  @State private var cancellables = Set<AnyCancellable>()
+  #if os(macOS)
+    @State private var windowID: ObjectIdentifier?
+  #endif
 
   var body: some View {
     ZStack(alignment: .bottom) {
@@ -16,6 +21,7 @@ struct RootView: View {
 
       VStack(alignment: .center, spacing: Constant.padding) {
         RootRoutes()
+          .environmentObject(viewModel)
       }
     }
     .background(Color.Neumorphic.main)
@@ -23,28 +29,50 @@ struct RootView: View {
     .onChange(of: navigator.path) { newPath in
       print("Current path:", newPath)
     }
-    .onAppear {
-      setupMenuBarNotifications()
-    }
-  }
-
-  private func setupMenuBarNotifications() {
+    .onDisappear { viewModel.cancelConversion() }
     #if os(macOS)
-    // 监听菜单栏设置通知
-    NotificationCenter.default.publisher(for: Notification.Name("OpenSettingsFromMenu"))
-      .sink { _ in
-        navigator.navigate("/settings")
-      }
-      .store(in: &cancellables)
-
-    // 监听菜单栏帮助通知
-    NotificationCenter.default.publisher(for: Notification.Name("OpenHelpFromMenu"))
-      .sink { _ in
-        navigator.navigate("/help")
-      }
-      .store(in: &cancellables)
+    .introspect(.window, on: .macOS(.v11, .v12, .v13, .v14, .v15, .v26)) { window in
+      windowID = ObjectIdentifier(window)
+      viewModel.window = window
+      AppDelegate.registerReadyWindow(window)
+    }
+    .onReceive(NotificationCenter.default.publisher(for: Notification.Name("OpenSettingsFromMenu"))) { notification in
+      guard isTargetWindow(for: notification) else { return }
+      navigator.navigate("/settings")
+    }
+    .onReceive(NotificationCenter.default.publisher(for: Notification.Name("OpenHelpFromMenu"))) { notification in
+      guard isTargetWindow(for: notification) else { return }
+      navigator.navigate("/help")
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .textConversionServiceDidReceiveText)) { notification in
+      navigateToHome(for: notification)
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .globalShortcutDidConvertText)) { notification in
+      navigateToHome(for: notification)
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .textServiceDidReceiveText)) { notification in
+      navigateToHome(for: notification)
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .convertTextFromMenu)) { notification in
+      navigateToHome(for: notification)
+    }
     #endif
   }
+
+  #if os(macOS)
+  private func navigateToHome(for notification: Notification) {
+    guard isTargetWindow(for: notification), navigator.path != "/home" else { return }
+    navigator.navigate("/home")
+  }
+
+  private func isTargetWindow(for notification: Notification) -> Bool {
+    guard let windowID,
+          let targetWindow = notification.object as? NSWindow ?? NSApp.keyWindow else {
+      return false
+    }
+    return ObjectIdentifier(targetWindow) == windowID
+  }
+  #endif
 }
 
 struct MainView_Previews: PreviewProvider {

--- a/OpenCCman/Scene/ShortcutSettingsScene.swift
+++ b/OpenCCman/Scene/ShortcutSettingsScene.swift
@@ -22,6 +22,11 @@ struct ShortcutSettingsScene: View {
             list
         }
         .background(Color.Neumorphic.main)
+        #if os(macOS)
+        .onAppear {
+            shortcutService.checkAccessibilityPermission()
+        }
+        #endif
     }
     
     var navi: some View {
@@ -89,7 +94,6 @@ struct ShortcutSettingsScene: View {
                         Spacer()
                         Toggle("", isOn: $shortcutService.isEnabled)
                             .toggleStyle(SwitchToggleStyle())
-                            .disabled(!shortcutService.hasAccessibilityPermission)
                     }
                     .padding()
                     .background(
@@ -219,4 +223,3 @@ struct ShortcutSettingsScene_Previews: PreviewProvider {
         ShortcutSettingsScene()
     }
 }
-

--- a/OpenCCman/Services/ChineseConversionService.swift
+++ b/OpenCCman/Services/ChineseConversionService.swift
@@ -1,0 +1,50 @@
+import Foundation
+import OpenCC
+
+actor ChineseConversionService {
+  static let shared = ChineseConversionService()
+
+  private static let cache = ConverterCache()
+
+  // NSServices must return synchronously. Share construction with the background
+  // path: SwiftyOpenCC's dictionary cache does not synchronize all of its reads.
+  nonisolated static func converter(options: ChineseConverter.Options) throws -> ChineseConverter {
+    try cache.converter(options: options)
+  }
+
+  nonisolated static func convertSynchronously(_ text: String, options: ChineseConverter.Options) throws -> String {
+    let converter = try converter(options: options)
+    // The dependency bridges through a null-terminated C string. Convert each
+    // null-delimited span so pasted U+0000 cannot silently discard the suffix.
+    guard text.utf8.contains(0) else { return converter.convert(text) }
+    return text.split(separator: "\0", omittingEmptySubsequences: false)
+      .map { converter.convert(String($0)) }
+      .joined(separator: "\0")
+  }
+
+  func convert(_ text: String, options: ChineseConverter.Options) throws -> String {
+    try Task.checkCancellation()
+    // Keep phrase context and every original separator intact.
+    let result = try Self.convertSynchronously(text, options: options)
+    try Task.checkCancellation()
+    return result
+  }
+
+  // ChineseConverter is immutable and thread-safe. Only its construction and
+  // this cache need a lock. The app exposes seven distinct option combinations.
+  private final class ConverterCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var converters: [Int: ChineseConverter] = [:]
+
+    func converter(options: ChineseConverter.Options) throws -> ChineseConverter {
+      lock.lock()
+      defer { lock.unlock() }
+      if let converter = converters[options.rawValue] {
+        return converter
+      }
+      let converter = try ChineseConverter(options: options)
+      converters[options.rawValue] = converter
+      return converter
+    }
+  }
+}

--- a/OpenCCman/Services/GlobalShortcutService.swift
+++ b/OpenCCman/Services/GlobalShortcutService.swift
@@ -24,21 +24,19 @@ extension KeyboardShortcuts.Name {
 
 // MARK: - Global Shortcut Service
 
+@MainActor
 class GlobalShortcutService: ObservableObject {
     static let shared = GlobalShortcutService()
 
     @Published var isEnabled: Bool = true {
         didSet {
-            if isEnabled {
-                setupKeyboardShortcuts()
-            } else {
-                KeyboardShortcuts.disable(.convertSelectedText)
-                KeyboardShortcuts.disable(.openSelectedText)
-            }
+            guard isEnabled != oldValue else { return }
+            KeyboardShortcuts.isEnabled = isEnabled
         }
     }
 
-    @Published var hasAccessibilityPermission = false
+    @Published private(set) var hasAccessibilityPermission = false
+    private var isPerformingAction = false
 
     private init() {
         checkAccessibilityPermission()
@@ -60,46 +58,25 @@ class GlobalShortcutService: ObservableObject {
     // MARK: - Shortcut Handling
 
     private func handleConvertShortcutPressed() {
-        print("Convert shortcut pressed! Converting selected text...")
         convertSelectedText()
     }
 
     private func handleOpenShortcutPressed() {
-        print("Open shortcut pressed! Opening selected text...")
         openSelectedText()
     }
 
     // MARK: - Permission Management
 
     func checkAccessibilityPermission() {
-        let trusted = AXIsProcessTrusted()
-        DispatchQueue.main.async {
-            self.hasAccessibilityPermission = trusted
-        }
-    }
-
-    private func isAccessibilityEnabled() -> Bool {
-        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
-        let accessibilityEnabled = AXIsProcessTrustedWithOptions(options)
-        return accessibilityEnabled
+        hasAccessibilityPermission = AXIsProcessTrusted()
     }
 
     func requestAccessibilityPermission() {
-        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
-        let trusted = AXIsProcessTrustedWithOptions(options)
-
-        DispatchQueue.main.async {
-            self.hasAccessibilityPermission = trusted
-        }
-
-        if !trusted {
+        checkAccessibilityPermission()
+        if !hasAccessibilityPermission {
             showAccessibilityPermissionAlert()
         }
     }
-
-
-
-
 
     private func showAccessibilityPermissionAlert() {
         let alert = NSAlert()
@@ -130,57 +107,37 @@ class GlobalShortcutService: ObservableObject {
         NSWorkspace.shared.open(url)
     }
 
-    // Apple Events permission methods removed - using Accessibility-only approach
-
     // MARK: - Public Methods
 
     func convertSelectedText() {
-        // Check accessibility permission first
-        guard hasAccessibilityPermission else {
-            print("Accessibility permission not granted")
-            requestAccessibilityPermission()
-            return
-        }
-
-        // For sandbox apps, we only need Accessibility permission
-        // The simulated key method works with just Accessibility permission
-
-        // Get the currently selected text using improved method
-        getSelectedTextImproved { [weak self] selectedText in
-            DispatchQueue.main.async {
-                guard let self = self, let text = selectedText, !text.isEmpty else {
-                    print("No text selected or text is empty")
-                    self?.showNoTextSelectedAlert()
-                    return
-                }
-
-                print("Selected text: \(text)")
-                // Convert the text
-                self.convertText(text)
-            }
-        }
+        performAction(convert: true)
     }
 
     func openSelectedText() {
-        // Check accessibility permission first
+        performAction(convert: false)
+    }
+
+    private func performAction(convert: Bool) {
+        guard !isPerformingAction else { return }
+        checkAccessibilityPermission()
         guard hasAccessibilityPermission else {
-            print("Accessibility permission not granted")
             requestAccessibilityPermission()
             return
         }
+        guard let sourceApplication = NSWorkspace.shared.frontmostApplication else { return }
 
-        // Get the currently selected text using improved method
-        getSelectedTextImproved { [weak self] selectedText in
-            DispatchQueue.main.async {
-                guard let self = self, let text = selectedText, !text.isEmpty else {
-                    print("No text selected or text is empty")
-                    self?.showNoTextSelectedAlert()
-                    return
-                }
+        isPerformingAction = true
+        Task {
+            defer { isPerformingAction = false }
+            guard let text = await getSelectedText(from: sourceApplication), !text.isEmpty else {
+                showNoTextSelectedAlert()
+                return
+            }
 
-                print("Selected text: \(text)")
-                // Open the text in app without conversion
-                self.bringAppToFrontAndSetTextOnly(originalText: text)
+            if convert {
+                await convertText(text, in: sourceApplication)
+            } else {
+                bringAppToFrontAndSetTextOnly(originalText: text)
             }
         }
     }
@@ -198,103 +155,46 @@ class GlobalShortcutService: ObservableObject {
     
     // MARK: - Text Capture
 
-    // MARK: - Mac App Store Sandbox-Optimized Text Capture
-
-    /// Optimized text capture for Mac App Store sandbox environment
-    /// Uses simulated Cmd+C which works reliably with proper entitlements:
-    /// - com.apple.security.automation.apple-events
-    /// - Accessibility permission from user
-    /// This approach is more reliable than Accessibility API for sandbox apps
-    private func getSelectedTextImproved(completion: @escaping (String?) -> Void) {
-        print("🔄 Starting Mac App Store optimized text capture")
-
-        // Simulated key method is the gold standard for sandbox apps
-        // It works consistently across all applications and doesn't require
-        // complex Accessibility API calls that can be problematic in sandbox
-        getSelectedTextBySimulatedKey { text in
-            if let text = text, !text.isEmpty {
-                print("✅ Text capture successful")
-                completion(text)
-            } else {
-                print("⚠️ No text captured - ensure text is selected first")
-                completion(nil)
-            }
-        }
-    }
-
-    // Accessibility method removed - simulated key is more reliable for sandbox apps
-
-    private func getSelectedTextBySimulatedKey(completion: @escaping (String?) -> Void) {
-        print("Using sandbox-optimized simulated key method")
-
-        // Store current clipboard content to restore later
+    private func getSelectedText(from application: NSRunningApplication) async -> String? {
         let pasteboard = NSPasteboard.general
-        let originalClipboard = pasteboard.string(forType: .string)
-        let originalChangeCount = pasteboard.changeCount
+        guard let originalClipboard = PasteboardSnapshot(pasteboard) else { return nil }
+        let originalChangeCount = originalClipboard.changeCount
 
-        // Clear clipboard to ensure we can detect new content
-        pasteboard.clearContents()
-
-        // Simulate Cmd+C using CGEvent (works reliably in sandbox)
-        simulateKeyPress(keyCode: CGKeyCode(8), modifiers: .maskCommand) { // 8 is kVK_ANSI_C
-            // Wait for clipboard to update (optimized timing for sandbox)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                let selectedText = pasteboard.string(forType: .string)
-                let newChangeCount = pasteboard.changeCount
-
-                // Restore original clipboard content after a short delay
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                    if let original = originalClipboard {
-                        pasteboard.clearContents()
-                        pasteboard.setString(original, forType: .string)
-                    }
-                }
-
-                // Check if we got new content (more robust detection)
-                if newChangeCount > originalChangeCount,
-                   let text = selectedText,
-                   text != originalClipboard,
-                   !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    print("✅ Captured text: \(text.prefix(50))...")
-                    completion(text)
-                } else {
-                    print("⚠️ No text captured - ensure text is selected")
-                    completion(nil)
-                }
+        // A copy changes ownership even when its text matches the existing clipboard.
+        // Leave the current contents intact if the source application cannot copy.
+        guard pasteboard.changeCount == originalChangeCount,
+              await simulateKeyPress(keyCode: CGKeyCode(kVK_ANSI_C), in: application) else { return nil }
+        for _ in 0..<20 {
+            guard (try? await Task.sleep(nanoseconds: 50_000_000)) != nil else { return nil }
+            guard NSWorkspace.shared.frontmostApplication?.processIdentifier == application.processIdentifier else { return nil }
+            let copiedChangeCount = pasteboard.changeCount
+            if copiedChangeCount != originalChangeCount {
+                let text = pasteboard.string(forType: .string)
+                originalClipboard.restore(to: pasteboard, ifUnchangedSince: copiedChangeCount)
+                return text
             }
         }
+        return nil
     }
 
-    private func simulateKeyPress(keyCode: CGKeyCode, modifiers: CGEventFlags, completion: @escaping () -> Void) {
-        // Create key down event (sandbox-compatible)
-        guard let keyDownEvent = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true) else {
-            print("❌ Failed to create key down event")
-            completion()
-            return
+    private func simulateKeyPress(keyCode: CGKeyCode, in application: NSRunningApplication) async -> Bool {
+        guard NSWorkspace.shared.frontmostApplication?.processIdentifier == application.processIdentifier,
+              let keyDownEvent = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true),
+              let keyUpEvent = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false) else {
+            return false
         }
-        keyDownEvent.flags = modifiers
-
-        // Create key up event
-        guard let keyUpEvent = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false) else {
-            print("❌ Failed to create key up event")
-            completion()
-            return
-        }
-        keyUpEvent.flags = modifiers
-
-        // Post events to system (works in sandbox with proper entitlements)
-        keyDownEvent.post(tap: .cghidEventTap)
-
-        // Small delay between key down and up for better reliability
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-            keyUpEvent.post(tap: .cghidEventTap)
-            completion()
-        }
+        keyDownEvent.flags = .maskCommand
+        keyUpEvent.flags = .maskCommand
+        keyDownEvent.postToPid(application.processIdentifier)
+        // Always balance key down with key up, even if the task was cancelled.
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        keyUpEvent.postToPid(application.processIdentifier)
+        return true
     }
-    
+
     // MARK: - Text Conversion
     
-    private func convertText(_ text: String) {
+    private func convertText(_ text: String, in application: NSRunningApplication) async {
         // Get current conversion options from UserDefaults
         let targetOptions = appDefaults[\.targetOptions]
         let variantOptions = appDefaults[\.variantOptions]
@@ -320,70 +220,38 @@ class GlobalShortcutService: ObservableObject {
         }
         
         do {
-            let converter = try ChineseConverter(options: options)
-            let convertedText = converter.convert(text)
-
-            print("📝 Original text: \(text)")
-            print("🔄 Converted text: \(convertedText)")
-
-            // Always try to replace the selected text in-place first
-            // This works for editable fields like text editors, browsers, etc.
-            replaceSelectedText(with: convertedText)
-
-            // Also bring the app to front and populate the input field for reference
-            // This provides a backup and shows the conversion result
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                self.bringAppToFrontAndSetText(originalText: text, convertedText: convertedText)
-            }
-
+            let convertedText = try await ChineseConversionService.shared.convert(text, options: options)
+            await replaceSelectedText(with: convertedText, in: application)
+            bringAppToFrontAndSetText(originalText: text, convertedText: convertedText)
         } catch {
-            print("❌ Conversion failed: \(error.localizedDescription)")
+            NSAlert(error: error).runModal()
         }
     }
-    
+
     // MARK: - Text Replacement
-    
-    private func replaceSelectedText(with convertedText: String) {
-        print("🔄 Attempting to replace selected text with converted text")
 
-        // Store original clipboard content
+    private func replaceSelectedText(with convertedText: String, in application: NSRunningApplication) async {
+        // Conversion may finish after the user has switched apps. Never paste into a new target.
+        guard NSWorkspace.shared.frontmostApplication?.processIdentifier == application.processIdentifier else { return }
         let pasteboard = NSPasteboard.general
-        let originalClipboard = pasteboard.string(forType: .string)
-
-        // Copy converted text to clipboard
-        pasteboard.clearContents()
-        pasteboard.setString(convertedText, forType: .string)
-
-        // Use CGEvent to simulate Cmd+V for more reliable pasting
-        // This works in most editable fields including text editors, browsers, etc.
-        simulateKeyPress(keyCode: CGKeyCode(9), modifiers: .maskCommand) { // 9 is kVK_ANSI_V
-            print("✅ Paste command sent - text should be replaced in editable field")
-
-            // Restore original clipboard content after a delay
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                if let original = originalClipboard {
-                    pasteboard.clearContents()
-                    pasteboard.setString(original, forType: .string)
-                    print("🔄 Original clipboard content restored")
-                } else {
-                    // If there was no original content, clear the clipboard
-                    pasteboard.clearContents()
-                    print("🧹 Clipboard cleared (no original content)")
-                }
-            }
+        guard let originalClipboard = PasteboardSnapshot(pasteboard),
+              pasteboard.changeCount == originalClipboard.changeCount else { return }
+        let replacementChangeCount = pasteboard.clearContents()
+        let written = pasteboard.setString(convertedText, forType: .string)
+        defer {
+            originalClipboard.restore(to: pasteboard, ifUnchangedSince: replacementChangeCount)
         }
+        guard written,
+              await simulateKeyPress(keyCode: CGKeyCode(kVK_ANSI_V), in: application) else { return }
+        // Event posting has no paste-completion callback. Allow the receiving app to read first.
+        try? await Task.sleep(nanoseconds: 800_000_000)
     }
-    
+
     // MARK: - App Integration
     
     private func bringAppToFrontAndSetText(originalText: String, convertedText: String) {
-        // Activate the app
-        NSApp.activate(ignoringOtherApps: true)
-
-        // Post notification to update the UI
-        NotificationCenter.default.post(
+        AppDelegate.postWindowNotification(
             name: .globalShortcutDidConvertText,
-            object: nil,
             userInfo: [
                 "originalText": originalText,
                 "convertedText": convertedText
@@ -392,22 +260,45 @@ class GlobalShortcutService: ObservableObject {
     }
 
     private func bringAppToFrontAndSetTextOnly(originalText: String) {
-        // Activate the app
-        NSApp.activate(ignoringOtherApps: true)
-
-        // Post notification to update the UI with just the original text
-        NotificationCenter.default.post(
+        AppDelegate.postWindowNotification(
             name: .textServiceDidReceiveText,
-            object: nil,
             userInfo: [
                 "originalText": originalText
             ]
         )
     }
 
-    // MARK: - Debug and Testing
+}
 
+// Preserve every item and representation, including rich text, images, and file URLs.
+// Refuse a partial snapshot rather than replacing clipboard data we cannot restore.
+struct PasteboardSnapshot {
+    private let items: [NSPasteboardItem]
+    let changeCount: Int
 
+    init?(_ pasteboard: NSPasteboard) {
+        let changeCount = pasteboard.changeCount
+        var copies: [NSPasteboardItem] = []
+        for item in pasteboard.pasteboardItems ?? [] {
+            let copy = NSPasteboardItem()
+            for type in item.types {
+                guard let data = item.data(forType: type), copy.setData(data, forType: type) else { return nil }
+            }
+            copies.append(copy)
+        }
+        guard pasteboard.changeCount == changeCount else { return nil }
+        items = copies
+        self.changeCount = changeCount
+    }
+
+    func restore(to pasteboard: NSPasteboard, ifUnchangedSince changeCount: Int) {
+        // Another copy belongs to the user and must survive our delayed restoration.
+        guard pasteboard.changeCount == changeCount else { return }
+        pasteboard.clearContents()
+        if !items.isEmpty {
+            pasteboard.writeObjects(items)
+        }
+    }
 }
 
 // MARK: - Notification Extension

--- a/OpenCCman/View/PickableView.swift
+++ b/OpenCCman/View/PickableView.swift
@@ -60,6 +60,9 @@ struct PickableView<T: Pickable>: View {
       .softRectangleStyle()
     }
     .fixedSize(horizontal: false, vertical: true)
+    .onChange(of: initialContent?.id) { selectedID in
+      selectionIndex = options.firstIndex(where: { $0.id == selectedID }) ?? -1
+    }
   }
 
   func binding(for index: Int) -> Binding<Bool> {
@@ -84,29 +87,26 @@ struct PickableSingleChoiceView: View {
   }
 
   var body: some View {
-    VStack {
+    Button {
+      if allowCancelSelect {
+        selected.toggle()
+      } else if selected == false {
+        selected = true
+      }
+    } label: {
       HStack {
         Text(title)
           .frame(maxWidth: .infinity, alignment: .leading)
         if selected {
           Image(systemName: "checkmark")
             .foregroundColor(color)
-        } else {
-//          Image(systemName: "circle")
-//            .foregroundColor(color)
+            .accessibilityHidden(true)
         }
       }
       .contentShape(Rectangle())
-      .onTapGesture {
-        if allowCancelSelect {
-          selected.toggle()
-        } else {
-          if selected == false {
-            selected = true
-          }
-        }
-      }
     }
+    .buttonStyle(.plain)
+    .accessibilityAddTraits(selected ? .isSelected : [])
     .frame(maxWidth: .infinity)
   }
 }

--- a/OpenCCman/View/SegmentView.swift
+++ b/OpenCCman/View/SegmentView.swift
@@ -25,23 +25,26 @@ struct SegmentView<T: Segmentable>: View {
           HStack(spacing: Constant.padding) {
             ForEach(options) { option in
               let active = option == seleted
-              ZStack {
-                if active {
-                  RoundedRectangle(cornerRadius: 20).fill(Color.accent.opacity(isEnabled ? 1 : 0.5))
-                    .softInnerShadow(RoundedRectangle(cornerRadius: 20), spread: 0.1, radius: 10)
-                } else {
-                  RoundedRectangle(cornerRadius: 20).fill(Color.Neumorphic.main.opacity(isEnabled ? 1 : 0.5))
-                    .softOuterShadow()
-                }
-                Text(option.title.localizedStringKey)
-                  .font(active ? .headline : .body)
-                  .foregroundColor(active ? Color.Neumorphic.main : Color.Neumorphic.secondary)
-                  .padding(Constant.padding)
-              }
-              .frame(minWidth: 60)
-              .onTapGesture {
+              Button {
                 seleted = option
+              } label: {
+                ZStack {
+                  if active {
+                    RoundedRectangle(cornerRadius: 20).fill(Color.accent.opacity(isEnabled ? 1 : 0.5))
+                      .softInnerShadow(RoundedRectangle(cornerRadius: 20), spread: 0.1, radius: 10)
+                  } else {
+                    RoundedRectangle(cornerRadius: 20).fill(Color.Neumorphic.main.opacity(isEnabled ? 1 : 0.5))
+                      .softOuterShadow()
+                  }
+                  Text(option.title.localizedStringKey)
+                    .font(active ? .headline : .body)
+                    .foregroundColor(active ? Color.Neumorphic.main : Color.Neumorphic.secondary)
+                    .padding(Constant.padding)
+                }
+                .frame(minWidth: 60)
               }
+              .buttonStyle(.plain)
+              .accessibilityAddTraits(active ? .isSelected : [])
             }
           }
           .padding(6)

--- a/OpenCCman/en.lproj/Localizable.strings
+++ b/OpenCCman/en.lproj/Localizable.strings
@@ -1,4 +1,5 @@
 // MARK: - IAP
+"Error" = "Error";
 "pro_lifetime" = "Lifetime Pro";
 "pro_lifetime_des" = "Pay once, use for a lifetime.";
 

--- a/OpenCCman/extensions/ViewExtensions.swift
+++ b/OpenCCman/extensions/ViewExtensions.swift
@@ -45,15 +45,17 @@ extension View {
     }
   }
 
-  func clearTextEdtorStyle() -> some View {
+  func clearTextEdtorStyle(isEditable: Bool = true) -> some View {
     #if os(macOS)
       introspect(.textEditor, on: .macOS(.v11, .v12, .v13, .v14, .v15, .v26)) { textEditor in
+        textEditor.isEditable = isEditable
         textEditor.textContainerInset = NSSize.init(width: 0, height: 1)
         textEditor.textContainer?.lineFragmentPadding = 0
         textEditor.backgroundColor = .clear
       }
     #else
       introspect(.textEditor, on: .iOS(.v14, .v15, .v16, .v17, .v18, .v26)) { textEditor in
+        textEditor.isEditable = isEditable
         textEditor.textContainerInset = .zero
         textEditor.textContainer.lineFragmentPadding = 0
         textEditor.backgroundColor = .clear

--- a/OpenCCman/zh-Hans.lproj/Localizable.strings
+++ b/OpenCCman/zh-Hans.lproj/Localizable.strings
@@ -146,3 +146,4 @@
 "accessibility_permission_step2" = "2. 在列表中找到「OpenCCman」";
 "accessibility_permission_step3" = "3. 勾选旁边的复选框";
 "accessibility_permission_step4" = "4. 返回 OpenCCman 并重试";
+"Error" = "错误";

--- a/OpenCCman/zh-Hant.lproj/Localizable.strings
+++ b/OpenCCman/zh-Hant.lproj/Localizable.strings
@@ -145,3 +145,4 @@
 "accessibility_permission_step2" = "2. 在列表中找到「OpenCCman」";
 "accessibility_permission_step3" = "3. 勾選旁邊的核取方塊";
 "accessibility_permission_step4" = "4. 返回 OpenCCman 並重試";
+"Error" = "錯誤";

--- a/Tests/Benchmarks/ConversionBenchmark.swift
+++ b/Tests/Benchmarks/ConversionBenchmark.swift
@@ -1,0 +1,86 @@
+// Baseline chunking copied verbatim from cc8c7e8 for reproducible comparison.
+// Both paths use the same warmed converter; this measures data processing, not UI.
+import Foundation
+import OpenCC
+  // Chunking helper: split large text by paragraphs first, then by size
+  func chunked(text: String, maxChunkLength: Int = 4000) -> [String] {
+    guard !text.isEmpty else { return [] }
+
+    // Prefer splitting by double newlines (paragraphs)
+    let paragraphs = text.components(separatedBy: "\n\n").filter { !$0.isEmpty }
+
+    var chunks: [String] = []
+    var current = ""
+
+    func flushCurrent() {
+      if !current.isEmpty { chunks.append(current); current.removeAll(keepingCapacity: true) }
+    }
+
+    if paragraphs.count > 1 {
+      for para in paragraphs {
+        if current.count + para.count + 2 <= maxChunkLength {
+          if current.isEmpty { current = para } else { current += "\n\n" + para }
+        } else if para.count <= maxChunkLength {
+          flushCurrent()
+          current = para
+        } else {
+          // Paragraph itself is too big, hard-split by size
+          var start = para.startIndex
+          while start < para.endIndex {
+            let end = para.index(start, offsetBy: maxChunkLength, limitedBy: para.endIndex) ?? para.endIndex
+            chunks.append(String(para[start ..< end]))
+            start = end
+          }
+          current.removeAll(keepingCapacity: true)
+        }
+      }
+      flushCurrent()
+    } else {
+      // No clear paragraph boundaries, split by size
+      var start = text.startIndex
+      while start < text.endIndex {
+        let end = text.index(start, offsetBy: maxChunkLength, limitedBy: text.endIndex) ?? text.endIndex
+        chunks.append(String(text[start ..< end]))
+        start = end
+      }
+    }
+
+    return chunks
+  }
+@main enum Benchmark {
+  static func main() async throws {
+    let options: ChineseConverter.Options = [.traditionalize, .twIdiom]
+    let converter = try ChineseConversionService.converter(options: options)
+    let fixtures = [
+      ("lost-prefix", "前段\n\n" + String(repeating: "汉", count: 4001)),
+      ("phrase-boundary", String(repeating: "a", count: 3999) + "鼠标"),
+      ("edge-newlines", "\n\n前段\n\n后段\n\n")
+    ]
+    for (name, input) in fixtures {
+      let old = chunked(text: input).map { converter.convert($0) }.joined(separator: "\n")
+      let expected = converter.convert(input)
+      let current = try await ChineseConversionService.shared.convert(input, options: options)
+      precondition(old != expected && current == expected)
+      print("REPRO \(name): old wrong; current matches OpenCC; old/output UTF8 bytes \(old.utf8.count)/\(current.utf8.count)")
+    }
+    let input = String(repeating: "鼠标里面的硅二极管坏了，导致光标分辨率降低。\n\n", count: 20000)
+    let pieces = chunked(text: input)
+    var oldTimes: [Double] = []
+    var newTimes: [Double] = []
+    for _ in 0..<5 {
+      let start = DispatchTime.now().uptimeNanoseconds
+      var old = ""
+      for piece in chunked(text: input) {
+        let converted = converter.convert(piece)
+        old += old.isEmpty ? converted : "\n" + converted
+      }
+      oldTimes.append(Double(DispatchTime.now().uptimeNanoseconds - start) / 1e6)
+      let next = DispatchTime.now().uptimeNanoseconds
+      let current = try await ChineseConversionService.shared.convert(input, options: options)
+      newTimes.append(Double(DispatchTime.now().uptimeNanoseconds - next) / 1e6)
+      precondition(!old.isEmpty && current == converter.convert(input))
+    }
+    print("BENCH chars=\(input.count), bytes=\(input.utf8.count), chunks=\(pieces.count), result-publications=\(pieces.count)->1")
+    print(String(format: "BENCH median processing (no UI; warmed converter; 5 runs): old %.2f ms, current %.2f ms", oldTimes.sorted()[2], newTimes.sorted()[2]))
+  }
+}

--- a/Tests/Regression/CoreChecks.swift
+++ b/Tests/Regression/CoreChecks.swift
@@ -1,0 +1,97 @@
+import Combine
+import Foundation
+import OpenCC
+
+@main enum CoreChecks {
+  @MainActor static func main() async throws {
+    defer {
+      appDefaults.defaults.removePersistentDomain(forName: coreSuite)
+      UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.lastVersionPromptedForReview.rawValue)
+    }
+    let fixtures = [
+      "", "\n\n前段\n\n后段\n\n", "\r\n鼠标\r\n\r\n台湾\r\n",
+      "前段\n\n" + String(repeating: "汉", count: 4001),
+      String(repeating: "a", count: 3999) + "鼠标",
+      "\n\n" + String(repeating: "甲\n\n", count: 1500) + "\n\n",
+      "👨‍👩‍👧‍👦🇹🇼e\u{301} 简体中文\t鼠标\u{2028}台湾",
+      String(repeating: "鼠标里面的硅二极管坏了，导致光标分辨率降低。\n\n", count: 5000)
+    ]
+    let allOptions: [ChineseConverter.Options] = [
+      .simplify, .traditionalize,
+      [.traditionalize, .twIdiom], [.traditionalize, .twStandard],
+      [.traditionalize, .twStandard, .twIdiom], [.traditionalize, .hkStandard],
+      [.traditionalize, .hkStandard, .twIdiom]
+    ]
+    for options in allOptions {
+      let converter = try ChineseConversionService.converter(options: options)
+      let reusedConverter = try ChineseConversionService.converter(options: options)
+      precondition(converter === reusedConverter, "Reuse the compiled converter")
+      for fixture in fixtures {
+        let result = try await ChineseConversionService.shared.convert(fixture, options: options)
+        precondition(result == converter.convert(fixture), "Full-text conversion must preserve OpenCC semantics")
+      }
+    }
+    let phrase = try await ChineseConversionService.shared.convert(fixtures[4], options: [.traditionalize, .twIdiom])
+    precondition(phrase == String(repeating: "a", count: 3999) + "滑鼠", "Do not split a phrase at the old 4000-character boundary")
+    let formatting = "\n\nASCII\n\n\n\r\n" + String(repeating: "x", count: 8001) + "\n\n"
+    let unchanged = try await ChineseConversionService.shared.convert(formatting, options: .traditionalize)
+    precondition(unchanged == formatting, "No insertion, deletion or reordering of separators")
+    let nullDelimited = "\0鼠标\0\0汉字\0"
+    let nullConverted = try await ChineseConversionService.shared.convert(nullDelimited, options: [.traditionalize, .twIdiom])
+    precondition(nullConverted == "\0滑鼠\0\0漢字\0", "The C-string bridge must not truncate text at U+0000")
+    let synchronousNullConverted = try ChineseConversionService.convertSynchronously(nullDelimited, options: [.traditionalize, .twIdiom])
+    precondition(synchronousNullConverted == nullConverted)
+    print("PASS: 7 option combinations × 8 fixtures; phrase boundaries, whitespace, Unicode and converter reuse")
+
+    weak var releasedModel: HomeViewModel?
+    autoreleasepool {
+      let model = HomeViewModel()
+      releasedModel = model
+    }
+    precondition(releasedModel == nil, "Combine subscriptions must not retain the view model")
+
+    let model = HomeViewModel()
+    var nonemptyResults = 0
+    let observation = model.$resultText.sink { if !$0.isEmpty { nonemptyResults += 1 } }
+    model.inputText = fixtures[3]
+    model.translate()
+    model.translate()
+    await waitUntilIdle(model)
+    precondition(TestNumbersPerDayManager.count == 1, "Repeated taps must not overlap or consume two uses")
+    precondition(nonemptyResults == 1, "Publish the final text once")
+    precondition(model.resultText.hasPrefix("前段\n\n"), "Do not drop the paragraph preceding a long paragraph")
+    precondition(model.localProgress == 1 && model.error == nil)
+    observation.cancel()
+
+    model.inputText = fixtures.last!
+    model.translate()
+    model.cancelConversion()
+    model.inputText = "鼠标"
+    model.regionOptions = .taiwan
+    model.translate()
+    await waitUntilIdle(model)
+    precondition(model.resultText == "滑鼠", "Cancelled work must not overwrite its replacement")
+    precondition(TestNumbersPerDayManager.count == 2, "Cancelled work must not consume quota")
+    model.inputText = ""
+    model.translate()
+    precondition(!model.isLoading && TestNumbersPerDayManager.count == 2)
+    TestNumbersPerDayManager.isToMax = true
+    model.inputText = "汉"
+    model.translate()
+    model.translate()
+    precondition(model.showingProAlert && !model.isLoading, "A repeated limit action must not hide the alert")
+    print("PASS: model release, repeated taps, single publication, cancellation/replacement, empty input and quota guard")
+  }
+
+  @MainActor private static func waitUntilIdle(_ model: HomeViewModel) async {
+    guard model.isLoading else { return }
+    await withCheckedContinuation { continuation in
+      var observation: AnyCancellable?
+      observation = model.$isLoading.filter { !$0 }.first().sink { _ in
+        continuation.resume()
+        observation?.cancel()
+        observation = nil
+      }
+    }
+  }
+}

--- a/Tests/Regression/CoreSupport.swift
+++ b/Tests/Regression/CoreSupport.swift
@@ -1,0 +1,28 @@
+// Only app integration is stubbed; Combine, SwiftUI, OpenCC and defaults are real.
+import Combine
+import Foundation
+import SwiftUI
+import SwiftyUserDefaults
+
+let coreSuite = "OpenCCman.CoreChecks.\(UUID().uuidString)"
+let appDefaults = DefaultsAdapter(defaults: UserDefaults(suiteName: coreSuite)!, keyStore: DefaultsKeys())
+extension DefaultsKeys {
+  var targetOptions: DefaultsKey<HomeViewModel.Language> { .init("targetOptions", defaultValue: .traditional) }
+  var variantOptions: DefaultsKey<HomeViewModel.Variant> { .init("variantOptions", defaultValue: .openCC) }
+  var regionOptions: DefaultsKey<HomeViewModel.Region> { .init("regionOptions", defaultValue: .notConvert) }
+}
+enum UserDefaultsKeys: String { case lastVersionPromptedForReview = "CoreChecks.reviewVersion" }
+protocol Segmentable: Identifiable, Equatable { var title: String { get } }
+extension Bundle { var appVersion: String { "core-checks" } }
+@MainActor enum ReviewHandler {
+  static var requests = 0
+  static func requestReview() { requests += 1 }
+}
+@MainActor enum TestNumbersPerDayManager {
+  static var isToMax = false
+  static var count = 0
+  static func add() { count += 1 }
+}
+extension Notification.Name {
+  static let globalShortcutDidConvertText = Notification.Name("GlobalShortcutDidConvertText")
+}

--- a/Tests/Regression/PasteboardChecks.swift
+++ b/Tests/Regression/PasteboardChecks.swift
@@ -1,0 +1,63 @@
+import AppKit
+
+@main
+enum PasteboardChecks {
+  static func main() {
+    // A private named pasteboard never reads or alters the user's general clipboard.
+    let board = NSPasteboard.withUniqueName()
+    defer { board.releaseGlobally() }
+
+    let textItem = NSPasteboardItem()
+    textItem.setString("原始文字", forType: .string)
+    let richText = Data("{\\rtf1 rich text}".utf8)
+    textItem.setData(richText, forType: .rtf)
+    let fileItem = NSPasteboardItem()
+    let imageBytes = Data([0x89, 0x50, 0x4e, 0x47, 0, 1, 2, 255])
+    fileItem.setData(imageBytes, forType: .png)
+    let fileURL = "file:///tmp/OpenCCman-pasteboard-regression.txt"
+    fileItem.setString(fileURL, forType: .fileURL)
+    precondition(board.writeObjects([textItem, fileItem]))
+
+    let original = PasteboardSnapshot(board)!
+    precondition(original.changeCount == board.changeCount)
+    let temporaryOwnership = board.clearContents()
+    precondition(board.setString("converted text", forType: .string))
+    precondition(board.changeCount == temporaryOwnership,
+                 "setString must retain the ownership returned by clearContents")
+    original.restore(to: board, ifUnchangedSince: temporaryOwnership)
+    precondition(board.pasteboardItems?.count == 2, "Preserve every clipboard item")
+    precondition(board.pasteboardItems?[0].string(forType: .string) == "原始文字")
+    precondition(board.pasteboardItems?[0].data(forType: .rtf) == richText,
+                 "Preserve rich text alongside plain text")
+    precondition(board.pasteboardItems?[1].data(forType: .png) == imageBytes,
+                 "Preserve image data byte-for-byte")
+    precondition(board.pasteboardItems?[1].string(forType: .fileURL) == fileURL,
+                 "Preserve file URL representations")
+
+    let beforePaste = PasteboardSnapshot(board)!
+    let pastedOwnership = board.clearContents()
+    board.setString("temporary paste", forType: .string)
+    board.clearContents()
+    board.setString("user copied afterwards", forType: .string)
+    let userOwnership = board.changeCount
+    beforePaste.restore(to: board, ifUnchangedSince: pastedOwnership)
+    precondition(board.string(forType: .string) == "user copied afterwards",
+                 "A delayed restore must preserve a later user copy")
+    precondition(board.changeCount == userOwnership,
+                 "A skipped restore must not claim pasteboard ownership")
+
+    board.clearContents()
+    board.setString("user copied afterwards", forType: .string)
+    precondition(board.changeCount != userOwnership,
+                 "Copying identical text is still an ownership change")
+
+    board.clearContents()
+    let empty = PasteboardSnapshot(board)!
+    let emptyTemporaryOwnership = board.clearContents()
+    board.setString("temporary", forType: .string)
+    empty.restore(to: board, ifUnchangedSince: emptyTemporaryOwnership)
+    precondition(board.pasteboardItems?.isEmpty ?? true, "Restore an originally empty clipboard")
+
+    print("PASS: multi-item text/RTF/image/file URL preservation, ownership checks, later user copy, identical text, empty clipboard.")
+  }
+}

--- a/Tests/Regression/QuotaChecks.swift
+++ b/Tests/Regression/QuotaChecks.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+@main
+enum QuotaChecks {
+  static func main() {
+    defer { UserDefaults.standard.removePersistentDomain(forName: quotaSuite) }
+
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = .autoupdatingCurrent
+    quotaNow = calendar.date(from: DateComponents(
+      year: 2026, month: 9, day: 12, hour: 23, minute: 59, second: 59
+    ))!
+    UserDefaults.standard.set(false, forKey: "isPro")
+
+    precondition(!TestNumbersPerDayManager.isToMax)
+    TestNumbersPerDayManager.add()
+    precondition(appDefaults.stored == ["2026-09-12": 1])
+    precondition(appDefaults.writes == 1, "The first conversion must persist once")
+
+    for _ in 2..<12 { TestNumbersPerDayManager.add() }
+    precondition(!TestNumbersPerDayManager.isToMax, "11 conversions still permits conversion")
+    TestNumbersPerDayManager.add()
+    precondition(TestNumbersPerDayManager.isToMax, "12 conversions reaches the daily cap")
+    precondition(appDefaults.stored == ["2026-09-12": 12])
+
+    quotaNow = quotaNow.addingTimeInterval(1)
+    appDefaults.writes = 0
+    precondition(!TestNumbersPerDayManager.isToMax, "Yesterday must not consume today's quota")
+    TestNumbersPerDayManager.add()
+    precondition(appDefaults.stored == ["2026-09-13": 1], "Rollover retains only today's count")
+    precondition(appDefaults.writes == 1, "Rollover must not persist an intermediate empty dictionary")
+
+    appDefaults.stored = ["2026-09-13": 12]
+    appDefaults.writes = 0
+    UserDefaults.standard.set(true, forKey: "isPro")
+    precondition(!TestNumbersPerDayManager.isToMax)
+    TestNumbersPerDayManager.add()
+    precondition(appDefaults.stored == ["2026-09-13": 12] && appDefaults.writes == 0,
+                 "Pro conversions do not consume quota")
+
+    print("PASS: daily quota boundaries, midnight rollover, Pro exemption, single persistence.")
+  }
+}

--- a/Tests/Regression/QuotaSupport.swift
+++ b/Tests/Regression/QuotaSupport.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+// Isolate the actual manager from the app's preferences and wall clock.
+let quotaSuite = "OpenCCman.QuotaRegression.\(UUID().uuidString)"
+enum UserDefaults {
+  static let standard = Foundation.UserDefaults(suiteName: quotaSuite)!
+}
+
+var quotaNow = Foundation.Date(timeIntervalSince1970: 0)
+func Date() -> Foundation.Date { quotaNow }
+
+enum UserDefaultsKeys: String { case isPro }
+enum FreeFeature { static let maxTestNumber = 12 }
+struct DefaultsKeys {
+  var testNumbersPerDay: String { "testNumbersPerDay" }
+}
+
+final class QuotaDefaults {
+  var stored: [String: Int] = [:]
+  var writes = 0
+
+  subscript(_ key: KeyPath<DefaultsKeys, String>) -> [String: Int] {
+    get { stored }
+    set {
+      stored = newValue
+      writes += 1
+    }
+  }
+}
+
+let appDefaults = QuotaDefaults()

--- a/docs/project-audit-2026-09-12.md
+++ b/docs/project-audit-2026-09-12.md
@@ -1,0 +1,104 @@
+# OpenCCman 项目审查与性能优化记录
+
+日期：2026-09-12。基线：`cc8c7e8`，审查前工作区干净。检查了全部 **43 个原有 Swift 文件、3956 行代码、88 个受 Git 跟踪文件**，以及锁定依赖中与实际调用有关的实现。新增一个共享转换服务。未改依赖版本、部署目标或付费产品标识。
+
+这是源码审查、独立行为回归和局部性能测量的记录；不把“未发现问题”解释为所有运行环境均无缺陷。依据以 Apple 官方文档、依赖锁定提交及可复现行为为准，没有把技能中的通用经验数字当作本项目的测量结果。
+
+**项目结构与关键流程**
+
+| 范围 | 路径/职责 | 核查结果 |
+|---|---|---|
+| 启动与系统集成 | OpenCCmanApp、AppDelegate；SwiftUI WindowGroup、状态栏、NSServices、权限 | 修复线程隔离、窗口通知目标、菜单快捷键配置 |
+| 转换主流程 | HomeViewModel、HomeScene；参数→OpenCC→结果→额度/评分 | 修复分块丢字/格式改变/词组断开、重入、泄漏、取消、错误展示、全文浏览 |
+| 全局快捷键 | GlobalShortcutService、ShortcutSettingsScene | 修复后台转换、监听累积、剪贴板恢复与权限刷新 |
+| 购买与额度 | IAPManager、ProScene、TestNumbersPerDayManager、ReviewHandler | 修复套餐选择、恢复行为、资格缓存、日计数、Scene 评分 |
+| 路由与偏好 | RootView、SettingsScene、ChangeLanguageScene、ChangeColorSchemeScene、PickableView | 每窗口持有模型；修复跨页面输入丢失、多窗口勾选不同步 |
+| 通用视图 | SegmentView、MyAppView、ProAlertView、CardReflectionView、BackButton、AlertView、CellButton、LoadingView | 选择控件补原生按钮及选中语义；其余未发现足以支持必要修改的问题 |
+| 内容页面 | HelpScene、FeedbackScene、OpenSourceScene | 补实际依赖缺失的开源声明；其他流程未发现确认缺陷 |
+| 数据与辅助 | Constants、MyAppModel、UserDefaultsKeys、OpenSourceModel；Styles、ButtonStyles；全部 extensions | 核查枚举/默认值、日期、剪贴板、字符串、格式化、可用性；仅修改涉及确认问题的实现 |
+| 工程与资源 | pbxproj、workspace、Package.resolved、plist、entitlements、三语 strings、两份 xcstrings、assets、README、LICENSE、gitignore | 资源引用/格式通过；补 UserDefaults 隐私 API 使用理由；删除无实际调用的 Apple Events 权限 |
+
+**确认的问题与处理**
+
+1. **分块导致正文丢失、顺序/换行改变、词组转换错误。** `前段\n\n` 后接 4001 个汉字时，旧分支直接清空未输出的前段；4000 字硬边界可切断“鼠标”；前后空段被过滤；片段拼接额外插入单换行。改为后台全文转换，保留上下文。独立回归已复现旧实现错误并验证修复结果。
+2. **大文本反复发布完整结果。** 原流程每段回主线程累加 `@Published resultText`。新流程仅完成后发布一次结果；转换中显示不定进度指示，完成后显示 100%。不伪造 OpenCC 未提供的字节级处理进度。
+3. **重复操作并发混写。** 模型守卫与按钮禁用共同防重入；持有任务以支持取消；取消后的旧任务不能覆盖新结果、显示旧错误或消费额度。空字符串不启动任务，连续触发额度限制不会把提示再次隐藏。
+4. **模型引用环与页面重建。** 原 `assign(to:on:self)` 与自身存储的 cancellable 形成环，HomeScene 又自行创建 ObservedObject。改用 `assign(to: &$options)`，由每个 RootView 的 StateObject 持有模型；页面切换保留草稿，窗口生命周期结束时取消转换。弱引用释放测试通过。[Apple Combine 生命周期](https://developer.apple.com/documentation/combine/publisher/assign(to:))、[StateObject](https://developer.apple.com/documentation/swiftui/stateobject)。
+5. **依赖创建与 C 字符串边界。** 所有入口共享缓存并串行创建转换器；应用当前只有七种有效选项组合。U+0000 会被依赖的 C 字符串接口视为结束，应用层按该分隔符分别转换后原样连接，避免静默丢弃后文。主页与同步服务使用同一处理。
+6. **结果无法完整浏览、转换错误不可见。** 结果 Text 被限制到 300pt，且没有内部滚动。改为只读 TextEditor，保留选取/复制与内部滚动；原生 isEditable 关闭编辑，源输入保持可编辑。错误绑定到可见 alert。未以此宣称已测得 UI 帧率改善。[Apple TextEditor](https://developer.apple.com/documentation/swiftui/texteditor)、[NSTextView.isEditable](https://developer.apple.com/documentation/appkit/nstextview/iseditable)、[UITextView.isEditable](https://developer.apple.com/documentation/uikit/uitextview/iseditable)。
+7. **多个窗口一起响应菜单/服务。** 通知携带目标 NSWindow；Root 和模型按窗口身份过滤。模型不再随首页卸载而消失；输入与转换菜单会导航到首页，避免后台扣额度但无可见结果。Root 使用 onReceive 管理订阅，不再在每次 onAppear 累积 cancellables。窗口尚未绑定时保留最新待投递请求，窗口就绪后延后一轮投递；窗口引用使用弱引用，避免保留已关闭窗口。
+8. **快捷键破坏剪贴板。** 原逻辑只保存字符串、提前清空，并有两次可能互相覆盖的延迟恢复。现在保存全部项目/表示格式，用 changeCount 判断变化与恢复所有权；相同文本也能识别新复制。恢复时若已有后续复制，则保留新内容。[Apple NSPasteboard.changeCount](https://developer.apple.com/documentation/appkit/nspasteboard/changecount)。
+9. **全局快捷键监听累积、同步转换阻塞与误粘贴。** handlers 只注册一次；切换开关使用 SDK 提供的启用属性；一次动作完成前不再重入。转换在 actor 中完成，事件投递到原 PID，目标 App 改变时放弃替换。移除原文及转换结果日志。菜单快捷键跟随录制值，并按依赖要求处理菜单打开期间的全局监听。[KeyboardShortcuts 2.4.0](https://github.com/sindresorhus/KeyboardShortcuts/blob/2.4.0/Sources/KeyboardShortcuts/KeyboardShortcuts.swift)。
+10. **权限状态过期及权限声明不符。** 操作前、应用激活和设置出现时刷新辅助功能权限；用户可在权限失效时关闭全局快捷键。移除没有 Apple Event 调用支撑的 automation.apple-events，并删除“sandbox 必定可靠”的注释。[Apple entitlement 定义](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.automation.apple-events)。
+11. **购买的套餐与点击卡片不一致。** 原循环总购买 `packages[0]`。现在传入当前卡片 package，采用 current Offering（无 current 时才回退指定 offering）；用户取消不作为错误处理。[RevenueCat Offering](https://www.revenuecat.com/docs/getting-started/displaying-products)。
+12. **自动恢复购买与断网误降级。** 日常检查仅获取 CustomerInfo；恢复只在用户明确点击时调用；nil 信息表示查询失败，不等于 Pro 失效，也不推进成功检查时间。添加 PurchasesDelegate，同步 SDK 获得的有效资格变化；代理地址在 configure 前设置。[恢复购买](https://www.revenuecat.com/docs/getting-started/restoring-purchases)、[资格更新](https://www.revenuecat.com/docs/customers/customer-info)、[初始化配置](https://www.revenuecat.com/docs/getting-started/configuring-sdk)。
+13. **日计数重复创建格式器与跨日双写。** 缓存固定公历、POSIX locale 的日期格式器；新增计数直接写今日单项字典。覆盖第 11/12 次门槛、午夜跨日、Pro 豁免、单次持久化。iOS 评分定位到前台 UIWindowScene，macOS 只在应用活跃时请求。[Apple QA1480](https://developer.apple.com/library/archive/qa/qa1480/_index.html)、[Scene 评分](https://developer.apple.com/documentation/storekit/skstorereviewcontroller/requestreview(in:))。
+14. **多窗口选择状态与标准操作语义缺失。** PickableView 在外部偏好变化时同步勾选；Segment/Pickable 用 Button 替代单独的 onTapGesture，保留原样式并提供 selected trait。[Apple 按钮语义建议](https://developer.apple.com/documentation/swiftui/view/ontapgesture(count:perform:))。
+15. **交付信息遗漏。** 增加 UserDefaults 所需的 PrivacyInfo.xcprivacy 与 CA92.1 理由，并加入资源；补 ColorVector、MSDisplayLink、KeyboardShortcuts 锁定版本的 MIT 全文；补新增错误标题的三语本地化。[Apple 隐私清单](https://developer.apple.com/documentation/bundleresources/privacy-manifest-files)。
+
+**性能证据**
+
+| 测量 | 基线 | 当前 | 方法与限制 |
+|---|---:|---:|---|
+| 48 万字符 / 1,360,000 UTF-8 字节处理 | 460.77 ms | 154.04 ms | 本机 Release、同一预热转换器、5 次中位数；包含旧分块/转换/拼接及新完整转换，不含 SwiftUI 渲染或用户交互 |
+| 同输入通过入仓基准脚本复测 | 479.85 ms | 161.29 ms | 独立 SwiftPM 可执行程序、5 次中位数；耗时下降约 66%，波动不影响发布次数或结果正确性 |
+| 上述输入的非空结果发布次数 | 121 | 1 | 由实际片段数和最终发布路径确定；核心回归同时观察发布次数 |
+| 2,000 次额度查询 | 37.08 ms | 1.95 ms | 独立日期/计数微基准；不是整应用速度，时间受本机环境影响 |
+| 跨日计数持久化 | 2 次 | 1 次 | 真实生产源码配隔离存储替身验证写入次数 |
+
+48 万字符样本的数据处理耗时约下降 **67%**。未测量端到端启动时间、FPS、峰值 RSS、电量或真实设备耗时，因此没有给出这些指标的改善比例。
+
+**验证与复现**
+
+在项目根目录运行：
+
+```sh
+python3 scripts/check-core.py
+python3 scripts/check-core.py --benchmark
+bash scripts/check-quota.sh
+bash scripts/check-pasteboard.sh
+git diff --check
+```
+
+- Core：实际 HomeViewModel/ChineseConversionService 源码，真实 Combine、SwiftUI、OpenCC、SwiftyUserDefaults；依赖 revision 从项目 Package.resolved 读取。7 组选项 × 8 类样本，加 U+0000 同步/异步一致性、模型释放、防重入、单次发布、取消替换、空输入与额度守卫。评分与额度副作用使用测试替身，不能由此推导 StoreKit 的真实行为。
+- Benchmark：保留 cc8c7e8 原分块函数作对照；校验三个旧缺陷在基线失败、当前与 OpenCC 一致，再运行相同输入的五次处理测量。可传 `--opencc-path`、`--defaults-path` 使用已有锁定提交的本地 checkout，减少重复下载。
+- Quota：生产文件原样编译；隔离 UserDefaults suite 和时钟，真正跨过 23:59:59→00:00:00。
+- Pasteboard：抽取并编译生产 PasteboardSnapshot；只用独立命名剪贴板，覆盖多项目文字/RTF/图片/文件 URL、空内容、相同文本、新复制保护，不操作系统通用剪贴板。
+- 全部应用 Swift 文件语法解析、工程/Info/entitlements/privacy plist、三语 strings、资源 JSON、diff 格式检查通过。
+- macOS 11/iOS 14 部署目标下，评分与结果编辑器做了真实 SDK 定向类型检查。选择控件、AppDelegate/全局服务的定向检查对部分第三方接口或样式使用替身；它们不能替代完整应用链接或运行时 UI 测试。
+- 没有运行 Xcode Build、模拟器、真实付款、签名应用跨 App 自动化，也没有安装/升级依赖或修改发布后台。
+
+**仍需后续验证或依赖修复的边界**
+
+- **SwiftyOpenCC 原生资源释放缺失仍在依赖内部。** 锁定提交 ChineseConverter 调用 CCConverterCreate，却没有 deinit 调用 CCConverterDestroy；C++ 实现使用 new。应用缓存将当前七组选项的创建次数限定在可复用集合，不能声称修好了上游析构。锁定 WeakValueCache 也有锁外读/锁内写，本项目已统一串行创建入口。[锁定 ChineseConverter](https://github.com/gewill/SwiftyOpenCC/blob/53f200cebe40eade3ebda025b0e8980e08cf23fa/Sources/OpenCC/ChineseConverter.swift)、[C++ 包装](https://github.com/gewill/SwiftyOpenCC/blob/53f200cebe40eade3ebda025b0e8980e08cf23fa/Sources/copencc/source.cpp)、[缓存实现](https://github.com/gewill/SwiftyOpenCC/blob/53f200cebe40eade3ebda025b0e8980e08cf23fa/Sources/OpenCC/WeakValueCache.swift)。
+- **NSServices 仍按同步协议返回。** 服务方法必须在返回前写回结果，因此其大文本转换仍可能占用服务线程；没有用阻塞等待异步任务来伪装优化。[Apple Services](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/SysServices/Articles/providing.html)。
+- **取消不能中断正在运行的 OpenCC C++ 调用。** 取消检查防止排队任务继续执行和旧结果回写，但已经进入原生同步计算时，需等该调用返回。
+- **CGEvent 复制/粘贴没有事务完成与来源标识。** 粘贴仍保留 800ms 容许时间；同 App 内选区改变、捕获期间用户复制、后台剪贴板工具写入，无法只凭 PID/changeCount 完全判别。需要签名 sandbox/TCC 环境与实际目标 App 验证。没有把独立剪贴板测试等同于跨 App 端到端测试。
+- **全部窗口关闭后的自动创建仍未实现兼容路径。** 最新请求会留在内存中，用户重开窗口后再投递；没有为 macOS 11 添加未经验证的创建窗口 selector。冷启动投递槽已通过类型检查，完整冷启动/闭窗重开仍需运行验证。
+- **真实购买/恢复/退款/跨设备资格**仍需 StoreKit Sandbox 验证；RevenueCat 接管交易验证、监听和完成，未误报业务层缺少 Transaction.finish/updates。隐私清单也不代替 App Store Connect 的实际隐私问卷。
+- **额度范围存在产品规则边界。** 现有日限额用于主页转换，macOS 自动转换入口原本未执行此门槛；没有在缺少产品规则时改变这些入口的付费行为。多个独立窗口临近额度上限时同时开始任务，也不构成跨任务额度预留协议。
+- **完整 UI/构建验证未执行。** TextEditor 的 Introspect 运行时匹配、键盘焦点/VoiceOver、所有窗口关闭后的重开流程仍需实际运行。原依赖也存在 Swift 6 语言模式警告，但项目当前使用 Swift 5 模式；未为消除升级预警强行迁移。
+- SwiftUIOverlayContainer 当前无直接 import/使用；尚无测量证明删除它能改善运行性能，因此保留锁定依赖，记录为后续清理候选。
+
+**覆盖清单**
+
+原有 Swift 文件全部进入审查分区：
+
+```text
+AppDelegate.swift · OpenCCmanApp.swift · Constants.swift · IAPManager.swift
+Helpers/ReviewHandler.swift
+Services/GlobalShortcutService.swift
+Model/OpenSourceModel.swift · MyAppModel.swift · TestNumbersPerDayManager.swift · UserDefaultsKeys.swift
+Scene/OpenSourceScene.swift · HelpScene.swift · HomeScene.swift · ChangeLanguageScene.swift
+Scene/ChangeColorSchemeScene.swift · ProScene.swift · FeedbackScene.swift · ShortcutSettingsScene.swift
+Scene/RootView.swift · SettingsScene.swift · HomeViewModel.swift
+View/LoadingView.swift · CellButton.swift · AlertView.swift · BackButton.swift
+View/CardReflectionView.swift · ProAlertView.swift · PickableView.swift · SegmentView.swift · MyAppView.swift
+Styles/ButtonStyles.swift · Styles.swift
+extensions/UIApplicationExtensions.swift · DateExtensions.swift · IntExtensions.swift
+extensions/BundleExtensions.swift · DoubleExtensions.swift · BoolExtensions.swift
+extensions/ColorExtensions.swift · StringExtensions.swift · ImageExtensions.swift
+extensions/SKProductExtensions.swift · ViewExtensions.swift
+```
+
+覆盖清单以项目源码为边界；第三方依赖审查集中于已使用 API、配置、许可证和已定位的问题，没有声称审计了每个依赖的全部实现。

--- a/scripts/check-core.py
+++ b/scripts/check-core.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Compile the actual conversion/model sources with their locked dependencies.
+
+Runs on macOS without Xcode Build, a simulator, or modifying the app's defaults.
+Optional local checkouts must match Package.resolved exactly.
+"""
+import argparse
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+root = Path(__file__).resolve().parents[1]
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--opencc-path", type=Path)
+parser.add_argument("--defaults-path", type=Path)
+parser.add_argument("--benchmark", action="store_true", help="Compare conversion processing with the cc8c7e8 baseline")
+args = parser.parse_args()
+pins = json.loads((root / "OpenCCman.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved").read_text())["pins"]
+pins = {pin["identity"]: pin for pin in pins}
+dependencies = []
+for identity, local in [("swiftyopencc", args.opencc_path), ("swiftyuserdefaults", args.defaults_path)]:
+    pin = pins[identity]
+    if local:
+        revision = subprocess.check_output(["git", "-C", str(local), "rev-parse", "HEAD"], text=True).strip()
+        if revision != pin["state"]["revision"]:
+            raise SystemExit(f"{identity}: local checkout does not match Package.resolved")
+        dependencies.append(f'.package(name: {json.dumps(identity)}, path: {json.dumps(str(local.resolve()))})')
+    else:
+        dependencies.append(f'.package(url: {json.dumps(pin["location"])}, revision: {json.dumps(pin["state"]["revision"])})')
+
+with tempfile.TemporaryDirectory(prefix="openccman-core-") as directory:
+    package = Path(directory)
+    sources = package / "Sources/CoreChecks"
+    sources.mkdir(parents=True)
+    for path in [
+        root / "OpenCCman/Services/ChineseConversionService.swift",
+        root / "OpenCCman/Scene/HomeViewModel.swift",
+        root / "Tests/Regression/CoreSupport.swift",
+        root / ("Tests/Benchmarks/ConversionBenchmark.swift" if args.benchmark else "Tests/Regression/CoreChecks.swift"),
+    ]:
+        shutil.copy2(path, sources / path.name)
+    (package / "Package.swift").write_text('''// swift-tools-version: 5.9
+import PackageDescription
+let package = Package(
+    name: "OpenCCmanCoreChecks",
+    platforms: [.macOS(.v11)],
+    dependencies: [\n''' + ",\n".join(dependencies) + '''\n],
+    targets: [.executableTarget(name: "CoreChecks", dependencies: [
+        .product(name: "OpenCC", package: "swiftyopencc"),
+        .product(name: "SwiftyUserDefaults", package: "swiftyuserdefaults")
+    ])]
+)
+''')
+    subprocess.run(["swift", "run", "-c", "release", "--package-path", str(package), "CoreChecks"], check=True)

--- a/scripts/check-pasteboard.sh
+++ b/scripts/check-pasteboard.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+audit_dir="$(mktemp -d "${TMPDIR:-/tmp}/openccman-pasteboard.XXXXXX")"
+trap 'rm -rf "$audit_dir"' EXIT
+
+# Compile the production type directly; extracting it avoids resolving the app's
+# unrelated Swift packages or adding a separate Xcode test target.
+python3 - "$repo_root/OpenCCman/Services/GlobalShortcutService.swift" "$audit_dir/PasteboardSnapshot.swift" <<'PY'
+from pathlib import Path
+import sys
+
+source = Path(sys.argv[1]).read_text()
+start = source.index("struct PasteboardSnapshot {")
+end = source.index("// MARK: - Notification Extension", start)
+Path(sys.argv[2]).write_text("import AppKit\n" + source[start:end])
+PY
+
+xcrun swiftc -O \
+  "$audit_dir/PasteboardSnapshot.swift" \
+  "$repo_root/Tests/Regression/PasteboardChecks.swift" \
+  -o "$audit_dir/check-pasteboard"
+
+"$audit_dir/check-pasteboard"

--- a/scripts/check-quota.sh
+++ b/scripts/check-quota.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+audit_dir="$(mktemp -d "${TMPDIR:-/tmp}/openccman-quota.XXXXXX")"
+trap 'rm -rf "$audit_dir"' EXIT
+
+xcrun swiftc -O \
+  "$repo_root/OpenCCman/Model/TestNumbersPerDayManager.swift" \
+  "$repo_root/Tests/Regression/QuotaSupport.swift" \
+  "$repo_root/Tests/Regression/QuotaChecks.swift" \
+  -o "$audit_dir/check-quota"
+
+"$audit_dir/check-quota"


### PR DESCRIPTION
大文本转换原先按 4000 字分块，会丢失长段前的正文、改变空行并切断词组；重复操作和全局通知也可能让转换结果串写。本次改为复用后台全文转换器，完成后一次发布，并修复窗口、快捷键、购买资格及交付信息中的确认问题。

### Log

- **问题或需求描述**：转换数据完整性、主线程重复更新、模型引用环、多窗口串写、剪贴板恢复及购买套餐/资格处理存在缺陷。
- **修复或实现思路**：统一转换缓存和线程入口，支持取消与防重入；每窗口保存模型并定向投递通知，冷启动时暂存最新请求；保留剪贴板全部表示格式并检查所有权；购买当前卡片套餐，查询失败保留 Pro 缓存，恢复购买仅由用户主动触发。
- **配套修复**：结果改为可滚动的只读文本控件；刷新辅助功能权限；补选择控件语义、UserDefaults 隐私清单及缺失开源声明；缓存日计数日期格式器并减少跨日写入。
- **复现路径**：`前段\n\n` 后接 4001 个汉字会丢前段；3999 个字符后接“鼠标”会切断词组；前后空段被过滤。

### 验证

- 核心回归通过：7 组选项 × 8 类文本，另覆盖 U+0000、模型释放、重复触发、单次发布、取消替换及额度守卫。
- 额度回归通过：11/12 次边界、午夜跨日、Pro 豁免、单次持久化。
- 独立命名剪贴板回归通过：多项目、RTF/图片/文件 URL、相同文本、新复制保护、空内容；不操作系统通用剪贴板。
- Swift 语法、plist/资源及 diff 检查通过；相关入口完成定向类型检查，部分第三方接口使用替身。
- Release 独立基准：48 万字符、5 次中位数，处理耗时 **479.85 → 161.29 ms**，非空结果发布 **121 → 1 次**；不包含 UI 渲染。

复现脚本：`scripts/check-core.py`（可加 `--benchmark`）、`scripts/check-quota.sh`、`scripts/check-pasteboard.sh`。完整文档依据、覆盖清单与边界见 `docs/project-audit-2026-09-12.md`。

### 验证边界

未运行完整 Xcode Build、模拟器或真实购买/签名跨 App 流程。上游 SwiftyOpenCC 缺失原生析构仍需依赖修复，本次通过缓存复用减少重复创建；NSServices 保留同步返回协议。CGEvent 仍无法确认复制来源或粘贴完成；全部窗口关闭时保留最新请求，待重开后投递。未改变依赖版本、部署目标或付费产品标识。
