### PR TITLE
实现 1.3 转换预设与 TXT 工作流，补齐跨窗口额度和 CI

### DIFF
--- a/.github/workflows/app-regression.yml
+++ b/.github/workflows/app-regression.yml
@@ -1,0 +1,33 @@
+name: App Regression
+
+on:
+  pull_request:
+    branches: [build]
+  push:
+    branches: [build]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: app-regression-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regression:
+    name: App Regression
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - name: Check project and source syntax
+        run: bash scripts/check-project.sh
+      - name: Check real conversion, presets and file workflow
+        run: python3 scripts/check-core.py
+      - name: Check quota reservations
+        run: bash scripts/check-quota.sh
+      - name: Check isolated pasteboard preservation
+        run: bash scripts/check-pasteboard.sh

--- a/OpenCCman.xcodeproj/project.pbxproj
+++ b/OpenCCman.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CC0912202600000000000041 /* TextFileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0912202600000000000042 /* TextFileService.swift */; };
+		CC0912202600000000000031 /* ConvertedTextDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0912202600000000000032 /* ConvertedTextDocument.swift */; };
+		CC0912202600000000000021 /* ConversionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0912202600000000000022 /* ConversionConfiguration.swift */; };
 		CC0912202600000000000001 /* ChineseConversionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0912202600000000000002 /* ChineseConversionService.swift */; };
 		0920E96C2E3F4D3C003C9715 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 0920E96B2E3F4D3C003C9715 /* InfoPlist.xcstrings */; };
 		095E17452E40746F0051BBB7 /* ServicesMenu.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 095E17442E40746F0051BBB7 /* ServicesMenu.xcstrings */; };
@@ -73,6 +76,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		CC0912202600000000000042 /* TextFileService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFileService.swift; sourceTree = "<group>"; };
+		CC0912202600000000000032 /* ConvertedTextDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvertedTextDocument.swift; sourceTree = "<group>"; };
+		CC0912202600000000000022 /* ConversionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversionConfiguration.swift; sourceTree = "<group>"; };
 		CC0912202600000000000002 /* ChineseConversionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChineseConversionService.swift; sourceTree = "<group>"; };
 		0920E96B2E3F4D3C003C9715 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		095E17442E40746F0051BBB7 /* ServicesMenu.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = ServicesMenu.xcstrings; sourceTree = "<group>"; };
@@ -158,6 +164,7 @@
 			isa = PBXGroup;
 			children = (
 				CC0912202600000000000002 /* ChineseConversionService.swift */,
+				CC0912202600000000000042 /* TextFileService.swift */,
 				09DBEC532E3BC69000DD9C5B /* GlobalShortcutService.swift */,
 			);
 			path = Services;
@@ -239,6 +246,8 @@
 				BE3AECA62B2EF43C00820673 /* MyAppModel.swift */,
 				BE3AECA82B2EF46000820673 /* OpenSourceModel.swift */,
 				BE3AECAA2B2EF46A00820673 /* TestNumbersPerDayManager.swift */,
+				CC0912202600000000000032 /* ConvertedTextDocument.swift */,
+				CC0912202600000000000022 /* ConversionConfiguration.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -401,6 +410,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				CC0912202600000000000001 /* ChineseConversionService.swift in Sources */,
+				CC0912202600000000000041 /* TextFileService.swift in Sources */,
+				CC0912202600000000000031 /* ConvertedTextDocument.swift in Sources */,
+				CC0912202600000000000021 /* ConversionConfiguration.swift in Sources */,
 				BE2C6D522B2D7ED000FC4112 /* ImageExtensions.swift in Sources */,
 				BEA770E92B2C904900AFA2F0 /* HomeScene.swift in Sources */,
 				BE3AECB52B2EF6F700820673 /* CardReflectionView.swift in Sources */,
@@ -586,7 +598,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OpenCCman/OpenCCman.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_ASSET_PATHS = "\"OpenCCman/Preview Content\"";
 				DEVELOPMENT_TEAM = RLK76T8Y89;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -611,7 +623,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.gewill.OpenCCman;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -629,7 +641,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = OpenCCman/OpenCCman.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_ASSET_PATHS = "\"OpenCCman/Preview Content\"";
 				DEVELOPMENT_TEAM = RLK76T8Y89;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -654,7 +666,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.gewill.OpenCCman;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;

--- a/OpenCCman/AppDelegate.swift
+++ b/OpenCCman/AppDelegate.swift
@@ -300,29 +300,11 @@
               return
           }
 
-          // Get current conversion options from UserDefaults
-          let targetOptions = appDefaults[\.targetOptions]
-          let variantOptions = appDefaults[\.variantOptions]
-          let regionOptions = appDefaults[\.regionOptions]
-
-          // Build conversion options
-          var options: ChineseConverter.Options = []
-          if targetOptions == .traditional {
-              options.formUnion(.traditionalize)
-              switch variantOptions {
-              case .openCC:
-                  break
-              case .taiwan:
-                  options.formUnion(.twStandard)
-              case .hongKong:
-                  options.formUnion(.hkStandard)
-              }
-              if regionOptions == .taiwan {
-                  options.formUnion(.twIdiom)
-              }
-          } else {
-              options.formUnion(.simplify)
-          }
+          let options = ConversionConfiguration(
+              target: appDefaults[\.targetOptions],
+              variant: appDefaults[\.variantOptions],
+              region: appDefaults[\.regionOptions]
+          ).options
 
           do {
               let convertedText = try ChineseConversionService.convertSynchronously(string, options: options)

--- a/OpenCCman/Model/ConversionConfiguration.swift
+++ b/OpenCCman/Model/ConversionConfiguration.swift
@@ -1,0 +1,67 @@
+import OpenCC
+
+/// The same option mapping is used by presets and the existing advanced controls.
+struct ConversionConfiguration: Equatable, Sendable {
+  var target: Language
+  var variant: Variant
+  var region: Region
+
+  var options: ChineseConverter.Options {
+    guard target == .traditional else { return .simplify }
+    var options: ChineseConverter.Options = .traditionalize
+    switch variant {
+    case .openCC: break
+    case .taiwan: options.formUnion(.twStandard)
+    case .hongKong: options.formUnion(.hkStandard)
+    }
+    if region == .taiwan { options.formUnion(.twIdiom) }
+    return options
+  }
+
+  var preset: Preset? {
+    // Variant/idiom controls are inactive for simplified output; preserve their
+    // saved values without incorrectly labelling this effective option custom.
+    if target == .simplified { return .simplified }
+    return Preset.allCases.first { $0.configuration == self }
+  }
+
+  enum Language: String, CaseIterable, Identifiable, Sendable {
+    case simplified = "Simplified Chinese"
+    case traditional = "Traditional Chinese"
+    var id: Self { self }
+    var title: String { rawValue }
+  }
+
+  enum Variant: String, CaseIterable, Identifiable, Sendable {
+    case openCC = "OpenCC Standard"
+    case taiwan = "Taiwan Standard"
+    case hongKong = "HongKong Standard"
+    var id: Self { self }
+    var title: String { rawValue }
+  }
+
+  enum Region: String, CaseIterable, Identifiable, Sendable {
+    case notConvert = "Not convert"
+    case taiwan = "Taiwan Idiom"
+    var id: Self { self }
+    var title: String { rawValue }
+  }
+
+  enum Preset: String, CaseIterable, Identifiable, Sendable {
+    case simplified = "preset_simplified"
+    case traditional = "preset_traditional"
+    case taiwan = "preset_taiwan"
+    case hongKong = "preset_hong_kong"
+    var id: Self { self }
+    var title: String { rawValue }
+
+    var configuration: ConversionConfiguration {
+      switch self {
+      case .simplified: return .init(target: .simplified, variant: .openCC, region: .notConvert)
+      case .traditional: return .init(target: .traditional, variant: .openCC, region: .notConvert)
+      case .taiwan: return .init(target: .traditional, variant: .taiwan, region: .taiwan)
+      case .hongKong: return .init(target: .traditional, variant: .hongKong, region: .notConvert)
+      }
+    }
+  }
+}

--- a/OpenCCman/Model/ConvertedTextDocument.swift
+++ b/OpenCCman/Model/ConvertedTextDocument.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// A value snapshot: subsequent edits/conversions cannot alter an open export.
+struct ConvertedTextDocument: FileDocument {
+  static var readableContentTypes: [UTType] { [.plainText] }
+  let text: String
+
+  init(text: String) { self.text = text }
+
+  init(configuration: ReadConfiguration) throws {
+    guard let data = configuration.file.regularFileContents else {
+      throw TextFileService.FileError.unsupportedFile
+    }
+    text = try TextFileService.decode(data)
+  }
+
+  func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+    FileWrapper(regularFileWithContents: Data(text.utf8))
+  }
+}

--- a/OpenCCman/Model/TestNumbersPerDayManager.swift
+++ b/OpenCCman/Model/TestNumbersPerDayManager.swift
@@ -1,6 +1,21 @@
 import Foundation
 
 enum TestNumbersPerDayManager {
+  // Reservations can be released by a task or view model's deinit. Protect the
+  // entire read/check/write operation, including the shared date formatter.
+  private static let lock = NSLock()
+  private static var pending: [UUID: String] = [:]
+
+  final class Reservation: Sendable {
+    fileprivate let id = UUID()
+
+    fileprivate init() {}
+
+    func commit() { TestNumbersPerDayManager.finish(self, successful: true) }
+    func release() { TestNumbersPerDayManager.finish(self, successful: false) }
+    deinit { release() }
+  }
+
   private static let dayFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: "en_US_POSIX")
@@ -10,23 +25,44 @@ enum TestNumbersPerDayManager {
     return formatter
   }()
 
-  static func add() {
-    guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.isPro.rawValue) == false else { return }
-
+  static func reserve() -> Reservation? {
+    lock.lock()
+    defer { lock.unlock() }
+    guard !isPro else { return Reservation() }
     let today = dayFormatter.string(from: Date())
-    let count = appDefaults[\.testNumbersPerDay][today] ?? 0
-    appDefaults[\.testNumbersPerDay] = [today: count + 1]
+    guard usedCount(on: today) < FreeFeature.maxTestNumber else { return nil }
+    let reservation = Reservation()
+    pending[reservation.id] = today
+    return reservation
   }
 
   static var isToMax: Bool {
-    guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.isPro.rawValue) == false else { return false }
-
+    lock.lock()
+    defer { lock.unlock() }
+    guard !isPro else { return false }
     let today = dayFormatter.string(from: Date())
+    return usedCount(on: today) >= FreeFeature.maxTestNumber
+  }
 
-    if let count = appDefaults[\.testNumbersPerDay][today] {
-      return count >= FreeFeature.maxTestNumber
-    } else {
-      return false
-    }
+  private static var isPro: Bool {
+    UserDefaults.standard.bool(forKey: UserDefaultsKeys.isPro.rawValue)
+  }
+
+  private static func usedCount(on day: String) -> Int {
+    (appDefaults[\.testNumbersPerDay][day] ?? 0)
+      + pending.values.filter { $0 == day }.count
+  }
+
+  private static func finish(_ reservation: Reservation, successful: Bool) {
+    lock.lock()
+    defer { lock.unlock() }
+    // Removing the token makes success, cancellation and cleanup idempotent.
+    guard let day = pending.removeValue(forKey: reservation.id), successful, !isPro else { return }
+    let today = dayFormatter.string(from: Date())
+    // A conversion belongs to its starting day. Do not overwrite today's
+    // count when yesterday's conversion finishes after midnight.
+    guard day == today else { return }
+    let count = appDefaults[\.testNumbersPerDay][today] ?? 0
+    appDefaults[\.testNumbersPerDay] = [today: count + 1]
   }
 }

--- a/OpenCCman/OpenCCman.entitlements
+++ b/OpenCCman/OpenCCman.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>

--- a/OpenCCman/Scene/HomeScene.swift
+++ b/OpenCCman/Scene/HomeScene.swift
@@ -2,12 +2,18 @@ import Neumorphic
 import OpenCC
 import SwiftUI
 import SwiftUIRouter
+import UniformTypeIdentifiers
 
 struct HomeScene: View {
   @EnvironmentObject var navigator: Navigator
 
   @AppStorage(UserDefaultsKeys.isPro.rawValue) var isPro: Bool = false
   @EnvironmentObject private var viewModel: HomeViewModel
+  @State private var showingImporter = false
+  @State private var showingExporter = false
+  @State private var exportDocument: ConvertedTextDocument?
+  @State private var exportFilename = "OpenCCman-converted.txt"
+  @State private var isDropTargeted = false
 
   var body: some View {
     ZStack(alignment: .top) {
@@ -29,6 +35,17 @@ struct HomeScene: View {
     }
     .frame(minWidth: 300)
     .overlay(ProAlertView(showingProAlert: $viewModel.showingProAlert))
+    .fileImporter(isPresented: $showingImporter, allowedContentTypes: [.plainText]) { result in
+      switch result {
+      case .success(let url): viewModel.importFile(url)
+      case .failure(let error): viewModel.handleFileFailure(error)
+      }
+    }
+    .fileExporter(isPresented: $showingExporter, document: exportDocument,
+                  contentType: .plainText, defaultFilename: exportFilename) { result in
+      if case .failure(let error) = result { viewModel.handleFileFailure(error) }
+      exportDocument = nil
+    }
     .alert(isPresented: Binding(
       get: { viewModel.error != nil },
       set: { if !$0 { viewModel.error = nil } }
@@ -87,7 +104,29 @@ struct HomeScene: View {
 
   var list: some View {
     VStack(alignment: .leading, spacing: Constant.padding) {
-      VStack(alignment: .leading) {
+      VStack(alignment: .leading, spacing: Constant.padding) {
+        HStack {
+          Text("Conversion Preset").font(.headline)
+          Spacer()
+          Menu {
+            ForEach(ConversionConfiguration.Preset.allCases) { preset in
+              Button {
+                viewModel.applyPreset(preset)
+              } label: {
+                if viewModel.selectedPreset == preset {
+                  Label(preset.title.localizedStringKey, systemImage: "checkmark")
+                } else {
+                  Text(preset.title.localizedStringKey)
+                }
+              }
+            }
+          } label: {
+            Label((viewModel.selectedPreset?.title ?? "preset_custom").localizedStringKey,
+                  systemImage: "chevron.down")
+          }
+          .accessibilityLabel(Text("Conversion Preset"))
+          .accessibilityValue(Text((viewModel.selectedPreset?.title ?? "preset_custom").localizedStringKey))
+        }
         SegmentView(title: "Target Language", options: HomeViewModel.Language.allCases, seleted: $viewModel.targetOptions)
         Group {
           SegmentView(title: "Variant", options: HomeViewModel.Variant.allCases, seleted: $viewModel.variantOptions)
@@ -111,28 +150,67 @@ struct HomeScene: View {
             else {
               return
             }
-            viewModel.inputText = string
+            viewModel.replaceSource(string)
           } label: {
             Image(systemName: "doc.on.clipboard")
           }
           .softButtonStyle(Circle(), padding: Padding.small)
+          .accessibilityLabel(Text("Paste Text"))
 
           Spacer()
-          Button(action: {
-            #if os(iOS)
-              UIApplication.shared.endEditing()
-            #endif
-            viewModel.translate()
-          }, label: {
-            Text("Convert")
-              .font(.headline)
-          })
-          .softButtonStyle(RoundedRectangle(cornerRadius: 20), padding: 10, mainColor: Color.accentColor, textColor: Color.Neumorphic.main)
-          .keyboardShortcut("t")
-          .disabled(viewModel.isLoading || viewModel.inputText.isEmpty)
+          if viewModel.isLoading {
+            Button("Cancel") { viewModel.cancelConversion() }
+              .softButtonStyle(RoundedRectangle(cornerRadius: 20), padding: 10)
+          } else {
+            Button(action: {
+              #if os(iOS)
+                UIApplication.shared.endEditing()
+              #endif
+              viewModel.translate()
+            }, label: {
+              Text("Convert")
+                .font(.headline)
+            })
+            .softButtonStyle(RoundedRectangle(cornerRadius: 20), padding: 10, mainColor: Color.accentColor, textColor: Color.Neumorphic.main)
+            .keyboardShortcut("t")
+            .disabled(viewModel.isImporting || viewModel.inputText.isEmpty)
+          }
         }
+        HStack {
+          Button {
+            showingImporter = true
+          } label: {
+            Label("Import TXT", systemImage: "square.and.arrow.down")
+          }
+          .disabled(viewModel.isImporting)
+          Spacer()
+          if viewModel.isImporting {
+            ProgressView().progressViewStyle(.circular)
+            Button("Cancel") { viewModel.cancelImport() }
+          }
+        }
+        if let filename = viewModel.sourceFilename {
+          Text(filename).font(.caption).lineLimit(1).truncationMode(.middle)
+        }
+        Text("text_file_hint")
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(10)
+          .contentShape(Rectangle())
+          .overlay(
+            RoundedRectangle(cornerRadius: 10)
+              .stroke(isDropTargeted ? Color.accentColor : Color.secondary.opacity(0.4),
+                      style: StrokeStyle(lineWidth: 1, dash: [4]))
+              .allowsHitTesting(false)
+          )
+          .onDrop(of: [.fileURL, .plainText], isTargeted: $isDropTargeted) { providers in
+            viewModel.importDroppedItems(providers)
+          }
         TextEditor(text: $viewModel.inputText)
           .clearTextEdtorStyle()
+          .accessibilityLabel(Text("Source"))
+          .disabled(viewModel.isImporting)
           .frame(maxWidth: .infinity, minHeight: 200, maxHeight: 300)
           .padding(Constant.padding)
           .background(
@@ -156,6 +234,19 @@ struct HomeScene: View {
             Image(systemName: "doc.on.doc")
           })
           .softButtonStyle(Circle(), padding: Padding.small)
+          .accessibilityLabel(Text("Copy Result"))
+          .disabled(viewModel.resultText.isEmpty)
+          Button {
+            guard let snapshot = viewModel.exportSnapshot else { return }
+            exportDocument = ConvertedTextDocument(text: snapshot.text)
+            exportFilename = snapshot.filename
+            showingExporter = true
+          } label: {
+            Image(systemName: "square.and.arrow.up")
+          }
+          .softButtonStyle(Circle(), padding: Padding.small)
+          .accessibilityLabel(Text("Export TXT"))
+          .disabled(viewModel.exportSnapshot == nil)
           Spacer()
           if viewModel.isLoading {
             ProgressView()
@@ -174,6 +265,9 @@ struct HomeScene: View {
                 }
               }
           }
+        }
+        if viewModel.resultText.isEmpty && viewModel.exportSnapshot != nil {
+          Text("previous_result_available").font(.caption).foregroundColor(.secondary)
         }
         TextEditor(text: .constant(viewModel.resultText))
           .clearTextEdtorStyle(isEditable: false)

--- a/OpenCCman/Scene/HomeViewModel.swift
+++ b/OpenCCman/Scene/HomeViewModel.swift
@@ -14,7 +14,15 @@ import SwiftyUserDefaults
 
 @MainActor
 class HomeViewModel: ObservableObject {
-  @Published var inputText: String = "鼠标里面的硅二极管坏了，导致光标分辨率降低。"
+  @Published var inputText: String = "鼠标里面的硅二极管坏了，导致光标分辨率降低。" {
+    didSet {
+      guard inputText != oldValue else { return }
+      cancelImport()
+      cancelConversion()
+      resultText = ""
+      exportSnapshot = nil
+    }
+  }
   @Published var resultText: String = ""
 
   @Published var options: ChineseConverter.Options = []
@@ -27,6 +35,14 @@ class HomeViewModel: ObservableObject {
   @Published var showingProAlert: Bool = false
   @Published var error: Error?
   @Published var isLoading: Bool = false
+  @Published private(set) var isImporting = false
+  @Published private(set) var sourceFilename: String?
+  struct ExportSnapshot: Equatable, Sendable {
+    let text: String
+    let filename: String
+  }
+  @Published private(set) var exportSnapshot: ExportSnapshot?
+  var resultFilename: String { exportSnapshot?.filename ?? "OpenCCman-converted.txt" }
   @Published var localProgress: Double = 0.0 // 0.0 ~ 1.0
 
   var localProgressPercent: Int {
@@ -35,6 +51,10 @@ class HomeViewModel: ObservableObject {
 
   private var cancellables = Set<AnyCancellable>()
   private var conversionTask: Task<Void, Never>?
+  private var reservation: TestNumbersPerDayManager.Reservation?
+  private var conversionID: UUID?
+  private var importTask: Task<Void, Never>?
+  private var importID: UUID?
   #if os(macOS)
     weak var window: NSWindow?
 
@@ -49,24 +69,7 @@ class HomeViewModel: ObservableObject {
   init() {
     Publishers.CombineLatest3($targetOptions, $variantOptions, $regionOptions)
       .map { targetOptions, variantOptions, regionOptions in
-        var options: ChineseConverter.Options = []
-        if targetOptions == .traditional {
-          options.formUnion(.traditionalize)
-          switch variantOptions {
-          case .openCC:
-            break
-          case .taiwan:
-            options.formUnion(.twStandard)
-          case .hongKong:
-            options.formUnion(.hkStandard)
-          }
-          if regionOptions == .taiwan {
-            options.formUnion(.twIdiom)
-          }
-        } else {
-          options.formUnion(.simplify)
-        }
-        return options
+        ConversionConfiguration(target: targetOptions, variant: variantOptions, region: regionOptions).options
       }
       .removeDuplicates()
       .assign(to: &$options)
@@ -98,8 +101,9 @@ class HomeViewModel: ObservableObject {
           DispatchQueue.main.async {
             guard self.accepts(notification) else { return }
             self.cancelConversion()
-            self.inputText = originalText
+            self.replaceSource(originalText)
             self.resultText = convertedText
+            self.exportSnapshot = ExportSnapshot(text: convertedText, filename: "OpenCCman-converted.txt")
             self.localProgress = 1.0
           }
         }
@@ -118,8 +122,9 @@ class HomeViewModel: ObservableObject {
           DispatchQueue.main.async {
             guard self.accepts(notification) else { return }
             self.cancelConversion()
-            self.inputText = originalText
+            self.replaceSource(originalText)
             self.resultText = convertedText
+            self.exportSnapshot = ExportSnapshot(text: convertedText, filename: "OpenCCman-converted.txt")
             self.localProgress = 1.0
           }
         }
@@ -137,8 +142,7 @@ class HomeViewModel: ObservableObject {
           DispatchQueue.main.async {
             guard self.accepts(notification) else { return }
             self.cancelConversion()
-            self.inputText = originalText
-            self.resultText = "" // Clear result text since we're not converting
+            self.replaceSource(originalText)
           }
         }
         .store(in: &cancellables)
@@ -159,14 +163,28 @@ class HomeViewModel: ObservableObject {
 
   // MARK: - response methods
 
+  var configuration: ConversionConfiguration {
+    ConversionConfiguration(target: targetOptions, variant: variantOptions, region: regionOptions)
+  }
+
+  var selectedPreset: ConversionConfiguration.Preset? { configuration.preset }
+
+  func applyPreset(_ preset: ConversionConfiguration.Preset) {
+    let configuration = preset.configuration
+    targetOptions = configuration.target
+    // Keep inactive advanced choices when switching to simplified output.
+    guard configuration.target == .traditional else { return }
+    variantOptions = configuration.variant
+    regionOptions = configuration.region
+  }
+
   func translate() {
-    guard !isLoading, !inputText.isEmpty else { return }
-    guard TestNumbersPerDayManager.isToMax == false else {
+    guard !isLoading, !isImporting, !inputText.isEmpty else { return }
+    guard let reservation = TestNumbersPerDayManager.reserve() else {
       showingProAlert = true
       return
     }
 
-    // Prepare UI state
     isLoading = true
     resultText = ""
     localProgress = 0.0
@@ -174,24 +192,37 @@ class HomeViewModel: ObservableObject {
 
     let currentInput = inputText
     let currentOptions = options
+    let filename = TextFileService.ImportedText(text: "", sourceFilename: sourceFilename).exportFilename
+    let identifier = UUID()
+    conversionID = identifier
+    self.reservation = reservation
 
     conversionTask = Task(priority: .userInitiated) { [weak self] in
       do {
         let result = try await ChineseConversionService.shared.convert(currentInput, options: currentOptions)
         try Task.checkCancellation()
-        guard let self else { return }
+        guard let self, self.conversionID == identifier else {
+          reservation.release()
+          return
+        }
         self.resultText = result
-        TestNumbersPerDayManager.add()
+        self.exportSnapshot = ExportSnapshot(text: result, filename: filename)
+        reservation.commit()
+        self.reservation = nil
         self.showReview()
         self.localProgress = 1.0
         self.isLoading = false
         self.conversionTask = nil
+        self.conversionID = nil
       } catch {
-        guard !Task.isCancelled, let self else { return }
+        reservation.release()
+        guard !Task.isCancelled, let self, self.conversionID == identifier else { return }
         self.error = error
+        self.reservation = nil
         self.isLoading = false
         self.localProgress = 0.0
         self.conversionTask = nil
+        self.conversionID = nil
       }
     }
   }
@@ -199,13 +230,75 @@ class HomeViewModel: ObservableObject {
   func cancelConversion() {
     conversionTask?.cancel()
     conversionTask = nil
+    conversionID = nil
+    reservation?.release()
+    reservation = nil
     isLoading = false
     localProgress = 0.0
     error = nil
   }
 
+  func replaceSource(_ text: String, sourceFilename: String? = nil) {
+    cancelImport()
+    cancelConversion()
+    inputText = text
+    self.sourceFilename = sourceFilename
+    resultText = ""
+    exportSnapshot = nil
+  }
+
+  func handleFileFailure(_ error: Error) {
+    let cocoaError = error as NSError
+    guard !(cocoaError.domain == NSCocoaErrorDomain && cocoaError.code == NSUserCancelledError) else { return }
+    self.error = error
+  }
+
+  func importFile(_ url: URL) {
+    startImport { try await TextFileService.read(url) }
+  }
+
+  func importDroppedItems(_ providers: [NSItemProvider]) -> Bool {
+    guard providers.count == 1, let provider = providers.first else {
+      error = TextFileService.FileError.multipleItems
+      return false
+    }
+    startImport { try await TextFileService.read(provider) }
+    return true
+  }
+
+  private func startImport(_ read: @escaping () async throws -> TextFileService.ImportedText) {
+    cancelImport()
+    error = nil
+    isImporting = true
+    let identifier = UUID()
+    importID = identifier
+    importTask = Task { [weak self] in
+      do {
+        let imported = try await read()
+        try Task.checkCancellation()
+        guard let self, self.importID == identifier else { return }
+        self.replaceSource(imported.text, sourceFilename: imported.sourceFilename)
+      } catch {
+        guard !Task.isCancelled, let self, self.importID == identifier else { return }
+        self.error = error
+        self.isImporting = false
+        self.importTask = nil
+        self.importID = nil
+      }
+    }
+  }
+
+  func cancelImport() {
+    importTask?.cancel()
+    importTask = nil
+    importID = nil
+    isImporting = false
+  }
+
   deinit {
     conversionTask?.cancel()
+    reservation?.release()
+    importTask?.cancel()
   }
 
   // MARK: - Review
@@ -219,29 +312,11 @@ class HomeViewModel: ObservableObject {
 
   // MARK: - Options
 
-  enum Language: String, CaseIterable, Identifiable, Segmentable, DefaultsSerializable {
-    case simplified = "Simplified Chinese"
-    case traditional = "Traditional Chinese"
-
-    var id: Language { self }
-    var title: String { rawValue }
-  }
-
-  enum Variant: String, CaseIterable, Identifiable, Segmentable, DefaultsSerializable {
-    case openCC = "OpenCC Standard"
-    case taiwan = "Taiwan Standard"
-    case hongKong = "HongKong Standard"
-
-    var id: Variant { self }
-    var title: String { rawValue }
-  }
-
-  enum Region: String, CaseIterable, Identifiable, Segmentable, DefaultsSerializable {
-    case notConvert = "Not convert"
-    case taiwan = "Taiwan Idiom"
-
-    var id: Region { self }
-    var title: String { rawValue }
-  }
-
+  typealias Language = ConversionConfiguration.Language
+  typealias Variant = ConversionConfiguration.Variant
+  typealias Region = ConversionConfiguration.Region
 }
+
+extension ConversionConfiguration.Language: Segmentable, DefaultsSerializable {}
+extension ConversionConfiguration.Variant: Segmentable, DefaultsSerializable {}
+extension ConversionConfiguration.Region: Segmentable, DefaultsSerializable {}

--- a/OpenCCman/Services/GlobalShortcutService.swift
+++ b/OpenCCman/Services/GlobalShortcutService.swift
@@ -195,30 +195,12 @@ class GlobalShortcutService: ObservableObject {
     // MARK: - Text Conversion
     
     private func convertText(_ text: String, in application: NSRunningApplication) async {
-        // Get current conversion options from UserDefaults
-        let targetOptions = appDefaults[\.targetOptions]
-        let variantOptions = appDefaults[\.variantOptions]
-        let regionOptions = appDefaults[\.regionOptions]
-        
-        // Build conversion options
-        var options: ChineseConverter.Options = []
-        if targetOptions == .traditional {
-            options.formUnion(.traditionalize)
-            switch variantOptions {
-            case .openCC:
-                break
-            case .taiwan:
-                options.formUnion(.twStandard)
-            case .hongKong:
-                options.formUnion(.hkStandard)
-            }
-            if regionOptions == .taiwan {
-                options.formUnion(.twIdiom)
-            }
-        } else {
-            options.formUnion(.simplify)
-        }
-        
+        let options = ConversionConfiguration(
+            target: appDefaults[\.targetOptions],
+            variant: appDefaults[\.variantOptions],
+            region: appDefaults[\.regionOptions]
+        ).options
+
         do {
             let convertedText = try await ChineseConversionService.shared.convert(text, options: options)
             await replaceSelectedText(with: convertedText, in: application)

--- a/OpenCCman/Services/TextFileService.swift
+++ b/OpenCCman/Services/TextFileService.swift
@@ -1,0 +1,207 @@
+import Foundation
+import UniformTypeIdentifiers
+
+enum TextFileService {
+  static let maximumBytes = 10 * 1024 * 1024
+  private static let queue = DispatchQueue(label: "OpenCCman.text-file", qos: .userInitiated)
+
+  struct ImportedText: Sendable {
+    let text: String
+    let sourceFilename: String?
+
+    var exportFilename: String {
+      guard let sourceFilename else { return "OpenCCman-converted.txt" }
+      let stem = (sourceFilename as NSString).deletingPathExtension
+      return "\(stem.isEmpty ? "OpenCCman" : stem)-converted.txt"
+    }
+  }
+
+  enum FileError: String, LocalizedError {
+    case unsupportedFile = "file_error_type"
+    case tooLarge = "file_error_size"
+    case invalidUTF8 = "file_error_encoding"
+    case multipleItems = "file_error_single_item"
+
+    var errorDescription: String? { NSLocalizedString(rawValue, comment: "Text import error") }
+  }
+
+  static func decode(_ data: Data) throws -> String {
+    guard data.count <= maximumBytes else { throw FileError.tooLarge }
+    let bytes = data.starts(with: [0xEF, 0xBB, 0xBF]) ? data.dropFirst(3) : data[...]
+    guard let text = String(data: bytes, encoding: .utf8) else { throw FileError.invalidUTF8 }
+    return text
+  }
+
+  static func read(_ url: URL) async throws -> ImportedText {
+    let cancellation = ReadCancellation()
+    return try await withTaskCancellationHandler(operation: {
+      try Task.checkCancellation()
+      return try await withCheckedThrowingContinuation { continuation in
+        guard cancellation.install(continuation) else { return }
+        queue.async {
+          do {
+            try cancellation.check()
+            let source = try OpenFile(url: url)
+            cancellation.finish(.success(try source.read(cancellation: cancellation)))
+          } catch { cancellation.finish(.failure(error)) }
+        }
+      }
+    }, onCancel: { cancellation.cancel() })
+  }
+
+  static func read(_ provider: NSItemProvider) async throws -> ImportedText {
+    let cancellation = ReadCancellation()
+    return try await withTaskCancellationHandler(operation: {
+      try Task.checkCancellation()
+      return try await withCheckedThrowingContinuation { continuation in
+        guard cancellation.install(continuation) else { return }
+        // Open the file inside the provider callback. The descriptor stays valid
+        // if the provider deletes its temporary URL after the callback returns.
+        let providerFilename = provider.suggestedName
+        let receiveFile: @Sendable (URL?, Error?) -> Void = { url, error in
+          do {
+            try cancellation.check()
+            if let error { throw error }
+            guard let url else { throw FileError.unsupportedFile }
+            let source = try OpenFile(url: url, sourceFilename: providerFilename)
+            queue.async {
+              do { cancellation.finish(.success(try source.read(cancellation: cancellation))) }
+              catch { cancellation.finish(.failure(error)) }
+            }
+          } catch { cancellation.finish(.failure(error)) }
+        }
+
+        if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+          let progress = provider.loadDataRepresentation(forTypeIdentifier: UTType.fileURL.identifier) { data, error in
+            let url = data.flatMap { URL(dataRepresentation: $0, relativeTo: nil) }
+            receiveFile(url, error)
+          }
+          cancellation.setProgress(progress)
+        } else if provider.suggestedName?.lowercased().hasSuffix(".txt") == true {
+          let progress = provider.loadFileRepresentation(forTypeIdentifier: UTType.plainText.identifier, completionHandler: receiveFile)
+          cancellation.setProgress(progress)
+        } else {
+          let progress = provider.loadObject(ofClass: NSString.self) { item, error in
+            queue.async {
+              do {
+                try cancellation.check()
+                if let error { throw error }
+                guard let text = item as? String else { throw FileError.unsupportedFile }
+                guard text.utf8.count <= maximumBytes else { throw FileError.tooLarge }
+                cancellation.finish(.success(ImportedText(text: text, sourceFilename: nil)))
+              } catch { cancellation.finish(.failure(error)) }
+            }
+          }
+          cancellation.setProgress(progress)
+        }
+      }
+    }, onCancel: { cancellation.cancel() })
+  }
+
+  private final class OpenFile: @unchecked Sendable {
+    let url: URL
+    let handle: FileHandle
+    let scoped: Bool
+    let sourceFilename: String
+
+    init(url: URL, sourceFilename: String? = nil) throws {
+      let filename: String
+      if let sourceFilename, sourceFilename.lowercased().hasSuffix(".txt") {
+        filename = (sourceFilename as NSString).lastPathComponent
+      } else {
+        filename = url.lastPathComponent
+      }
+      guard url.isFileURL, (filename as NSString).pathExtension.lowercased() == "txt" else { throw FileError.unsupportedFile }
+      let scoped = url.startAccessingSecurityScopedResource()
+      do {
+        let values = try url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        guard values.isRegularFile == true else { throw FileError.unsupportedFile }
+        if let size = values.fileSize, size > maximumBytes { throw FileError.tooLarge }
+        handle = try FileHandle(forReadingFrom: url)
+      } catch {
+        if scoped { url.stopAccessingSecurityScopedResource() }
+        throw error
+      }
+      self.url = url
+      self.scoped = scoped
+      self.sourceFilename = filename
+    }
+
+    func read(cancellation: ReadCancellation) throws -> ImportedText {
+      var data = Data()
+      while true {
+        try cancellation.check()
+        // Read at most limit + 1 even when size metadata is missing or stale.
+        let count = min(64 * 1024, maximumBytes - data.count + 1)
+        guard let chunk = try handle.read(upToCount: count), !chunk.isEmpty else { break }
+        data.append(chunk)
+        guard data.count <= maximumBytes else { throw FileError.tooLarge }
+      }
+      try cancellation.check()
+      return ImportedText(text: try decode(data), sourceFilename: sourceFilename)
+    }
+
+    deinit {
+      try? handle.close()
+      if scoped { url.stopAccessingSecurityScopedResource() }
+    }
+  }
+
+  private final class ReadCancellation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+    private var progress: Progress?
+    private var continuation: CheckedContinuation<ImportedText, Error>?
+    private var finished = false
+
+    func install(_ continuation: CheckedContinuation<ImportedText, Error>) -> Bool {
+      lock.lock()
+      let cancelled = cancelled
+      if !cancelled { self.continuation = continuation }
+      lock.unlock()
+      if cancelled { continuation.resume(throwing: CancellationError()) }
+      return !cancelled
+    }
+
+    func finish(_ result: Result<ImportedText, Error>) {
+      lock.lock()
+      guard !finished else { lock.unlock(); return }
+      finished = true
+      let continuation = continuation
+      self.continuation = nil
+      progress = nil
+      lock.unlock()
+      continuation?.resume(with: result)
+    }
+
+    func check() throws {
+      lock.lock()
+      let cancelled = cancelled
+      lock.unlock()
+      if cancelled { throw CancellationError() }
+    }
+
+    func cancel() {
+      lock.lock()
+      cancelled = true
+      finished = true
+      let progress = progress
+      self.progress = nil
+      let continuation = continuation
+      self.continuation = nil
+      lock.unlock()
+      // A provider is allowed to stop without calling back after cancellation.
+      // Resume here, and ignore a late callback through finish's single gate.
+      continuation?.resume(throwing: CancellationError())
+      progress?.cancel()
+    }
+
+    func setProgress(_ progress: Progress) {
+      lock.lock()
+      if !finished { self.progress = progress }
+      let cancelled = cancelled
+      lock.unlock()
+      if cancelled { progress.cancel() }
+    }
+  }
+}

--- a/OpenCCman/en.lproj/Localizable.strings
+++ b/OpenCCman/en.lproj/Localizable.strings
@@ -70,3 +70,21 @@
 "accessibility_permission_step2" = "2. Find \"OpenCCman\" in the list";
 "accessibility_permission_step3" = "3. Check the box next to it";
 "accessibility_permission_step4" = "4. Return to OpenCCman and try again";
+
+// MARK: - Presets and text files
+"Conversion Preset" = "Conversion Preset";
+"preset_simplified" = "Simplified Chinese";
+"preset_traditional" = "Traditional · OpenCC";
+"preset_taiwan" = "Taiwan · Standard + Idioms";
+"preset_hong_kong" = "Hong Kong · Traditional";
+"preset_custom" = "Custom";
+"Import TXT" = "Import TXT";
+"Export TXT" = "Export TXT";
+"Paste Text" = "Paste Text";
+"Copy Result" = "Copy Result";
+"previous_result_available" = "The previous successful result is still available to export.";
+"text_file_hint" = "Import, or drop here, one UTF-8 TXT file or plain text, up to 10 MiB.";
+"file_error_type" = "Choose a regular TXT file encoded as UTF-8, or drop plain text.";
+"file_error_size" = "This text exceeds the 10 MiB import limit.";
+"file_error_encoding" = "This file is not valid UTF-8. Save it as UTF-8 and try again.";
+"file_error_single_item" = "Import one file or text item at a time.";

--- a/OpenCCman/zh-Hans.lproj/Localizable.strings
+++ b/OpenCCman/zh-Hans.lproj/Localizable.strings
@@ -147,3 +147,21 @@
 "accessibility_permission_step3" = "3. 勾选旁边的复选框";
 "accessibility_permission_step4" = "4. 返回 OpenCCman 并重试";
 "Error" = "错误";
+
+// MARK: - Presets and text files
+"Conversion Preset" = "转换预设";
+"preset_simplified" = "简体中文";
+"preset_traditional" = "繁体 · OpenCC";
+"preset_taiwan" = "台湾正体＋台湾词组";
+"preset_hong_kong" = "香港繁体";
+"preset_custom" = "自定义";
+"Import TXT" = "导入 TXT";
+"Export TXT" = "导出 TXT";
+"Paste Text" = "粘贴文本";
+"Copy Result" = "复制结果";
+"previous_result_available" = "仍可导出上一次成功转换的结果。";
+"text_file_hint" = "导入或拖至此处：单个 UTF-8 TXT 文件或纯文本，最大 10 MiB。";
+"file_error_type" = "请选择 UTF-8 编码的普通 TXT 文件，或拖入纯文本。";
+"file_error_size" = "文本超过 10 MiB 导入上限。";
+"file_error_encoding" = "文件不是有效的 UTF-8 编码。请另存为 UTF-8 后重试。";
+"file_error_single_item" = "一次只能导入一个文件或文本项目。";

--- a/OpenCCman/zh-Hant.lproj/Localizable.strings
+++ b/OpenCCman/zh-Hant.lproj/Localizable.strings
@@ -146,3 +146,21 @@
 "accessibility_permission_step3" = "3. 勾選旁邊的核取方塊";
 "accessibility_permission_step4" = "4. 返回 OpenCCman 並重試";
 "Error" = "錯誤";
+
+// MARK: - Presets and text files
+"Conversion Preset" = "轉換預設";
+"preset_simplified" = "簡體中文";
+"preset_traditional" = "繁體 · OpenCC";
+"preset_taiwan" = "臺灣正體＋臺灣詞組";
+"preset_hong_kong" = "香港繁體";
+"preset_custom" = "自訂";
+"Import TXT" = "匯入 TXT";
+"Export TXT" = "匯出 TXT";
+"Paste Text" = "貼上文字";
+"Copy Result" = "複製結果";
+"previous_result_available" = "仍可匯出上一次成功轉換的結果。";
+"text_file_hint" = "匯入或拖至此處：單個 UTF-8 TXT 檔案或純文字，上限 10 MiB。";
+"file_error_type" = "請選擇 UTF-8 編碼的一般 TXT 檔案，或拖入純文字。";
+"file_error_size" = "文字超過 10 MiB 匯入上限。";
+"file_error_encoding" = "檔案不是有效的 UTF-8 編碼。請另存為 UTF-8 後重試。";
+"file_error_single_item" = "一次只能匯入一個檔案或文字項目。";

--- a/README.md
+++ b/README.md
@@ -6,6 +6,29 @@ An OpenCC UI for iOS、iPadOS、macOS by SwiftUI with ❤️
 
 [![Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917](./assets/Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg)](https://apps.apple.com/app/id6474449401)
 
+## 1.3
+
+- Four presets: Simplified, OpenCC Traditional, Taiwan Standard + Idioms, and Hong Kong Traditional. Existing advanced preferences remain available.
+- Import one UTF-8 `.txt` file (with or without BOM), up to 10 MiB. Drop a file or plain text onto the indicated drop area.
+- Export the latest successful conversion as a new UTF-8 file without BOM. Line endings, blank lines and Unicode are preserved.
+- Cancel conversion or import without accepting late results. Failed imports leave the current draft intact.
+- Daily homepage quota reservations are shared across windows; only successful conversions consume a use.
+
+iOS 14 / macOS 11 remain supported. Batch conversion, Shortcuts, history and custom dictionaries are not part of 1.3.
+
+## Development checks
+
+Run on macOS with Xcode command-line tools and Python 3; no simulator is required:
+
+```sh
+bash scripts/check-project.sh
+python3 scripts/check-core.py
+bash scripts/check-quota.sh
+bash scripts/check-pasteboard.sh
+```
+
+Core checks compile the actual app model/services with the dependencies pinned in `Package.resolved`. All preferences and pasteboards used by these checks are isolated from the running app. See [1.3 validation](docs/version-1.3-validation.md) for coverage and remaining release checks.
+
 ## Thanks
 
 1. [BYVoid](https://github.com/BYVoid)‘s original SDK [OpenCC](https://github.com/BYVoid/OpenCC) 

--- a/Tests/Regression/CoreChecks.swift
+++ b/Tests/Regression/CoreChecks.swift
@@ -57,12 +57,17 @@ import OpenCC
     model.translate()
     model.translate()
     await waitUntilIdle(model)
-    precondition(TestNumbersPerDayManager.count == 1, "Repeated taps must not overlap or consume two uses")
+    precondition(coreQuotaCount == 1, "Repeated taps must not overlap or consume two uses")
     precondition(nonemptyResults == 1, "Publish the final text once")
     precondition(model.resultText.hasPrefix("前段\n\n"), "Do not drop the paragraph preceding a long paragraph")
     precondition(model.localProgress == 1 && model.error == nil)
     observation.cancel()
 
+    let previousExport = model.exportSnapshot
+    precondition(previousExport != nil)
+    model.translate()
+    model.cancelConversion()
+    precondition(model.exportSnapshot == previousExport, "Cancellation keeps the latest successful export")
     model.inputText = fixtures.last!
     model.translate()
     model.cancelConversion()
@@ -71,16 +76,18 @@ import OpenCC
     model.translate()
     await waitUntilIdle(model)
     precondition(model.resultText == "滑鼠", "Cancelled work must not overwrite its replacement")
-    precondition(TestNumbersPerDayManager.count == 2, "Cancelled work must not consume quota")
+    precondition(coreQuotaCount == 2, "Cancelled work must not consume quota")
     model.inputText = ""
     model.translate()
-    precondition(!model.isLoading && TestNumbersPerDayManager.count == 2)
-    TestNumbersPerDayManager.isToMax = true
+    precondition(!model.isLoading && coreQuotaCount == 2)
+    for _ in 2..<12 { TestNumbersPerDayManager.reserve()!.commit() }
     model.inputText = "汉"
     model.translate()
     model.translate()
     precondition(model.showingProAlert && !model.isLoading, "A repeated limit action must not hide the alert")
     print("PASS: model release, repeated taps, single publication, cancellation/replacement, empty input and quota guard")
+    try await checkPresetsAndFiles()
+    try await checkProviders()
   }
 
   @MainActor private static func waitUntilIdle(_ model: HomeViewModel) async {

--- a/Tests/Regression/CoreSupport.swift
+++ b/Tests/Regression/CoreSupport.swift
@@ -5,23 +5,27 @@ import SwiftUI
 import SwiftyUserDefaults
 
 let coreSuite = "OpenCCman.CoreChecks.\(UUID().uuidString)"
-let appDefaults = DefaultsAdapter(defaults: UserDefaults(suiteName: coreSuite)!, keyStore: DefaultsKeys())
+enum UserDefaults {
+  static let standard = Foundation.UserDefaults(suiteName: coreSuite)!
+}
+let appDefaults = DefaultsAdapter(defaults: UserDefaults.standard, keyStore: DefaultsKeys())
 extension DefaultsKeys {
   var targetOptions: DefaultsKey<HomeViewModel.Language> { .init("targetOptions", defaultValue: .traditional) }
   var variantOptions: DefaultsKey<HomeViewModel.Variant> { .init("variantOptions", defaultValue: .openCC) }
   var regionOptions: DefaultsKey<HomeViewModel.Region> { .init("regionOptions", defaultValue: .notConvert) }
+  var testNumbersPerDay: DefaultsKey<[String: Int]> { .init("testNumbersPerDay", defaultValue: [:]) }
 }
-enum UserDefaultsKeys: String { case lastVersionPromptedForReview = "CoreChecks.reviewVersion" }
+enum UserDefaultsKeys: String {
+  case lastVersionPromptedForReview = "CoreChecks.reviewVersion"
+  case isPro
+}
+enum FreeFeature { static let maxTestNumber = 12 }
+var coreQuotaCount: Int { appDefaults[\.testNumbersPerDay].values.reduce(0, +) }
 protocol Segmentable: Identifiable, Equatable { var title: String { get } }
 extension Bundle { var appVersion: String { "core-checks" } }
 @MainActor enum ReviewHandler {
   static var requests = 0
   static func requestReview() { requests += 1 }
-}
-@MainActor enum TestNumbersPerDayManager {
-  static var isToMax = false
-  static var count = 0
-  static func add() { count += 1 }
 }
 extension Notification.Name {
   static let globalShortcutDidConvertText = Notification.Name("GlobalShortcutDidConvertText")

--- a/Tests/Regression/FileChecks.swift
+++ b/Tests/Regression/FileChecks.swift
@@ -1,0 +1,110 @@
+import Combine
+import Foundation
+import OpenCC
+
+@MainActor func checkPresetsAndFiles() async throws {
+  let presets: [(ConversionConfiguration.Preset, ChineseConverter.Options)] = [
+    (.simplified, .simplify), (.traditional, .traditionalize),
+    (.taiwan, [.traditionalize, .twStandard, .twIdiom]),
+    (.hongKong, [.traditionalize, .hkStandard])
+  ]
+  for (preset, expected) in presets {
+    precondition(preset.configuration.options == expected)
+    precondition(preset.configuration.preset == preset)
+  }
+  precondition(ConversionConfiguration(target: .traditional, variant: .hongKong, region: .taiwan).preset == nil)
+  precondition(ConversionConfiguration(target: .simplified, variant: .hongKong, region: .taiwan).preset == .simplified)
+
+  let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: directory) }
+  let file = directory.appendingPathComponent("文稿.txt")
+  let fixtures = ["", "\r\n汉字\r\n\r\n", "👨‍👩‍👧‍👦🇹🇼e\u{301}\0鼠标\0\0\n"]
+  for text in fixtures {
+    for bom in [Data(), Data([0xEF, 0xBB, 0xBF])] {
+      try (bom + Data(text.utf8)).write(to: file)
+      let imported = try await TextFileService.read(file)
+      precondition(imported.text == text, "UTF-8 import preserves exact text, removing only the BOM")
+      precondition(imported.exportFilename == "文稿-converted.txt")
+    }
+  }
+  precondition(TextFileService.ImportedText(text: "", sourceFilename: nil).exportFilename == "OpenCCman-converted.txt")
+  let exactLimit = Data(repeating: 0x61, count: TextFileService.maximumBytes)
+  let exactDecoded = try TextFileService.decode(exactLimit)
+  precondition(exactDecoded.utf8.count == TextFileService.maximumBytes)
+
+  let invalid = directory.appendingPathComponent("invalid.txt")
+  try Data([0xFF, 0xFE, 0x80]).write(to: invalid)
+  do {
+    _ = try await TextFileService.read(invalid)
+    preconditionFailure("Invalid UTF-8 must be rejected")
+  } catch TextFileService.FileError.invalidUTF8 {}
+
+  let large = directory.appendingPathComponent("large.txt")
+  FileManager.default.createFile(atPath: large.path, contents: nil)
+  let handle = try FileHandle(forWritingTo: large)
+  try handle.truncate(atOffset: UInt64(TextFileService.maximumBytes + 1))
+  try handle.close()
+  do {
+    _ = try await TextFileService.read(large)
+    preconditionFailure("Oversized files must be rejected before unbounded allocation")
+  } catch TextFileService.FileError.tooLarge {}
+  do {
+    _ = try await TextFileService.read(directory)
+    preconditionFailure("Directories are not text files")
+  } catch TextFileService.FileError.unsupportedFile {}
+
+  let cancelledRead = Task { try await TextFileService.read(file) }
+  cancelledRead.cancel()
+  do {
+    _ = try await cancelledRead.value
+    preconditionFailure("Cancelled reads must not return a replacement draft")
+  } catch is CancellationError {}
+
+  UserDefaults.standard.set(true, forKey: UserDefaultsKeys.isPro.rawValue)
+  defer { UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.isPro.rawValue) }
+  let model = HomeViewModel()
+  model.replaceSource("保留原稿", sourceFilename: "原稿.txt")
+  model.resultText = "保留结果"
+  let quotaBefore = coreQuotaCount
+  model.importFile(invalid)
+  await waitForImport(model)
+  precondition(model.inputText == "保留原稿" && model.resultText == "保留结果")
+  precondition(model.error != nil && !model.isImporting)
+  model.importFile(file)
+  model.cancelImport()
+  precondition(model.inputText == "保留原稿" && model.resultText == "保留结果")
+  model.importFile(file)
+  await waitForImport(model)
+  precondition(model.inputText == fixtures.last! && model.resultText.isEmpty)
+  precondition(model.exportSnapshot == nil, "A new imported draft cannot export an unrelated prior result")
+  precondition(model.error == nil && coreQuotaCount == quotaBefore)
+
+  model.applyPreset(.taiwan)
+  precondition(model.selectedPreset == .taiwan && model.options == presets[2].1)
+  model.applyPreset(.simplified)
+  precondition(model.variantOptions == .taiwan && model.regionOptions == .taiwan, "Inactive advanced preferences survive simplified output")
+  precondition(coreQuotaCount == quotaBefore, "Imports and presets never consume quota")
+
+  model.inputText = String(repeating: "汉字鼠标\n", count: 100_000)
+  model.translate()
+  model.importFile(file)
+  await waitForImport(model)
+  // Drain the serial conversion actor: an earlier result must not overwrite the import.
+  _ = try await ChineseConversionService.shared.convert("", options: .simplify)
+  await Task.yield()
+  precondition(model.inputText == fixtures.last! && model.resultText.isEmpty && !model.isLoading)
+  print("PASS: presets, UTF-8/BOM/Unicode/NUL files, size limit, invalid input, cancellation and import replacement")
+}
+
+@MainActor private func waitForImport(_ model: HomeViewModel) async {
+  guard model.isImporting else { return }
+  await withCheckedContinuation { continuation in
+    var observation: AnyCancellable?
+    observation = model.$isImporting.filter { !$0 }.first().sink { _ in
+      continuation.resume()
+      observation?.cancel()
+      observation = nil
+    }
+  }
+}

--- a/Tests/Regression/ProviderChecks.swift
+++ b/Tests/Regression/ProviderChecks.swift
@@ -1,0 +1,70 @@
+import Foundation
+import UniformTypeIdentifiers
+
+/// Real Foundation providers, without a pasteboard, host app, or service stub.
+@MainActor func checkProviders() async throws {
+  // A broken cancellation continuation must fail this executable rather than
+  // hang CI. Normal progress is signalled by the loader, never by a sleep.
+  let watchdog = DispatchWorkItem {
+    fatalError("NSItemProvider regression exceeded its 10-second completion deadline")
+  }
+  DispatchQueue.global().asyncAfter(deadline: .now() + 10, execute: watchdog)
+  defer { watchdog.cancel() }
+
+  let directory = FileManager.default.temporaryDirectory.appendingPathComponent("OpenCCman-providers-\(UUID().uuidString)")
+  try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: directory) }
+
+  let filename = "含 空格#文稿.txt"
+  let url = directory.appendingPathComponent(filename)
+  let text = "\r\n鼠标\0台湾\r\n\n👨‍👩‍👧‍👦e\u{301}\n"
+  try (Data([0xEF, 0xBB, 0xBF]) + Data(text.utf8)).write(to: url)
+  let urlProvider = NSItemProvider(object: url as NSURL)
+  precondition(urlProvider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier))
+  let importedFile = try await TextFileService.read(urlProvider)
+  precondition(importedFile.text == text, "NSURL providers preserve whitespace/Unicode/NUL and remove one BOM")
+  precondition(importedFile.sourceFilename == filename, "File URLs must decode spaces and escaped punctuation")
+  precondition(importedFile.exportFilename == "含 空格#文稿-converted.txt")
+
+  let stringProvider = NSItemProvider(object: text as NSString)
+  precondition(!stringProvider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier))
+  let importedString = try await TextFileService.read(stringProvider)
+  precondition(importedString.text == text, "NSString providers preserve plain text exactly")
+  precondition(importedString.sourceFilename == nil)
+  precondition(importedString.exportFilename == "OpenCCman-converted.txt")
+
+  let loaderStarted = ProviderLoaderSignal()
+  let silentProvider = NSItemProvider()
+  silentProvider.registerDataRepresentation(forTypeIdentifier: UTType.fileURL.identifier, visibility: .all) { _ in
+    // Intentionally never invoke the completion callback, including on cancel.
+    Task { @MainActor in loaderStarted.signal() }
+    return Progress(totalUnitCount: 1)
+  }
+  let pendingRead = Task { try await TextFileService.read(silentProvider) }
+  await loaderStarted.wait()
+  pendingRead.cancel()
+  do {
+    _ = try await pendingRead.value
+    preconditionFailure("Cancelling an unresolved provider must throw CancellationError")
+  } catch is CancellationError {
+    // Completion proves the service resumed its own continuation on cancel.
+  }
+  print("PASS: real NSURL/NSString providers and cancellation without a provider callback")
+}
+
+@MainActor private final class ProviderLoaderSignal {
+  private var signalled = false
+  private var continuation: CheckedContinuation<Void, Never>?
+
+  func wait() async {
+    guard !signalled else { return }
+    await withCheckedContinuation { continuation = $0 }
+  }
+
+  func signal() {
+    signalled = true
+    let continuation = continuation
+    self.continuation = nil
+    continuation?.resume()
+  }
+}

--- a/Tests/Regression/QuotaChecks.swift
+++ b/Tests/Regression/QuotaChecks.swift
@@ -13,20 +13,39 @@ enum QuotaChecks {
     UserDefaults.standard.set(false, forKey: "isPro")
 
     precondition(!TestNumbersPerDayManager.isToMax)
-    TestNumbersPerDayManager.add()
+    let first = TestNumbersPerDayManager.reserve()!
+    precondition(appDefaults.writes == 0, "Reservations must not persist unfinished work")
+    first.commit()
+    first.commit()
+    first.release()
     precondition(appDefaults.stored == ["2026-09-12": 1])
     precondition(appDefaults.writes == 1, "The first conversion must persist once")
 
-    for _ in 2..<12 { TestNumbersPerDayManager.add() }
+    for _ in 2..<12 { TestNumbersPerDayManager.reserve()!.commit() }
     precondition(!TestNumbersPerDayManager.isToMax, "11 conversions still permits conversion")
-    TestNumbersPerDayManager.add()
+    let lastSlot = TestNumbersPerDayManager.reserve()!
+    precondition(TestNumbersPerDayManager.reserve() == nil, "Another window cannot reserve the last slot twice")
+    precondition(TestNumbersPerDayManager.isToMax)
+    lastSlot.release()
+    lastSlot.commit()
+    precondition(!TestNumbersPerDayManager.isToMax, "Failed or cancelled work returns its slot")
+    autoreleasepool {
+      let abandoned = TestNumbersPerDayManager.reserve()!
+      withExtendedLifetime(abandoned) { precondition(TestNumbersPerDayManager.isToMax) }
+    }
+    precondition(!TestNumbersPerDayManager.isToMax, "Deallocation releases an abandoned reservation")
+    let yesterday = TestNumbersPerDayManager.reserve()!
+    yesterday.commit()
     precondition(TestNumbersPerDayManager.isToMax, "12 conversions reaches the daily cap")
     precondition(appDefaults.stored == ["2026-09-12": 12])
 
+    appDefaults.stored = ["2026-09-12": 11]
+    let crossingMidnight = TestNumbersPerDayManager.reserve()!
     quotaNow = quotaNow.addingTimeInterval(1)
     appDefaults.writes = 0
     precondition(!TestNumbersPerDayManager.isToMax, "Yesterday must not consume today's quota")
-    TestNumbersPerDayManager.add()
+    TestNumbersPerDayManager.reserve()!.commit()
+    crossingMidnight.commit()
     precondition(appDefaults.stored == ["2026-09-13": 1], "Rollover retains only today's count")
     precondition(appDefaults.writes == 1, "Rollover must not persist an intermediate empty dictionary")
 
@@ -34,10 +53,23 @@ enum QuotaChecks {
     appDefaults.writes = 0
     UserDefaults.standard.set(true, forKey: "isPro")
     precondition(!TestNumbersPerDayManager.isToMax)
-    TestNumbersPerDayManager.add()
+    let pro = TestNumbersPerDayManager.reserve()!
+    pro.commit()
     precondition(appDefaults.stored == ["2026-09-13": 12] && appDefaults.writes == 0,
                  "Pro conversions do not consume quota")
 
-    print("PASS: daily quota boundaries, midnight rollover, Pro exemption, single persistence.")
+    // A conversion started as Pro stays exempt even if entitlement changes.
+    let expiredPro = TestNumbersPerDayManager.reserve()!
+    UserDefaults.standard.set(false, forKey: "isPro")
+    expiredPro.commit()
+    precondition(appDefaults.writes == 0)
+
+    appDefaults.stored = [:]
+    DispatchQueue.concurrentPerform(iterations: 100) { _ in
+      TestNumbersPerDayManager.reserve()?.commit()
+    }
+    precondition(appDefaults.stored == ["2026-09-13": 12], "Concurrent windows cannot overrun the cap")
+    precondition(appDefaults.writes == 12)
+    print("PASS: quota reservations, concurrent cap, idempotent cleanup, cancellation, deinit, midnight and Pro exemption.")
   }
 }

--- a/docs/version-1.3-validation.md
+++ b/docs/version-1.3-validation.md
@@ -1,0 +1,41 @@
+# OpenCCman 1.3 implementation and validation
+
+Date: 2026-09-12. Baseline: PR #1, merged into `build` at `59fcad781045182bc7f032910a23be656dbe514b`.
+
+## Implemented behavior
+
+The four presets and all existing controls share `ConversionConfiguration`, also used by macOS Services and global shortcuts. The original defaults keys and enum raw values remain compatible. Switching to simplified output preserves inactive advanced choices.
+
+The file workflow accepts a single UTF-8 TXT file, including a leading BOM, up to 10 MiB. Reads use a dedicated queue, bounded chunks and balanced security-scoped access. Dropped providers are opened while their temporary URL is valid. Cancellation completes even when a provider never invokes its callback. Import failure/cancellation preserves the current draft; successful import or an input edit invalidates older work. Export uses an immutable successful-result snapshot and writes UTF-8 without BOM.
+
+Quota reservations include unfinished conversions across windows. Reservation, limit checking and success accounting use one lock. Success commits once; cancellation, failure and deallocation release idempotently. Work belongs to its starting date, so a late completion cannot consume or overwrite the new day's quota. Pro uses and existing macOS service/shortcut pricing remain unchanged.
+
+## Automated verification
+
+- Project/plist/localization validation and all production Swift source parsing.
+- Actual HomeViewModel, conversion service, file service, configuration, document and quota code compiled against the exact locked OpenCC and SwiftyUserDefaults revisions.
+- Seven conversion combinations × eight text fixtures; phrase boundary, newline, empty paragraph, Unicode, U+0000 and converter reuse checks.
+- Model release, repeated taps, one result publication, cancellation/replacement, empty input, quota guard and export snapshot preservation.
+- All presets, custom recognition, UTF-8/BOM/CRLF/emoji/combining characters/NUL, exact size boundary, oversized and invalid files, import cancellation, draft/result preservation and stale conversion rejection.
+- Real NSURL and NSString providers, escaped filenames and a provider that never calls back after cancellation.
+- Quota cap, two windows claiming the last slot, 100 concurrent attempts, idempotent commit/release, abandoned reservations, midnight rollover and Pro exemption.
+- Isolated NSPasteboard tests preserve complete multi-item/type data and do not overwrite a newer copy.
+
+Commands are listed in the README and run in the `App Regression` GitHub Actions job. These do not launch simulators or modify the user's clipboard/preferences.
+
+## Build and signed sandbox verification
+
+- Complete generic macOS and iOS Debug builds passed with pinned dependencies; no simulator was launched.
+- A separate validation bundle identifier was signed with the local Apple Development identity. Its actual entitlements include App Sandbox and user-selected read/write access.
+- In that signed app, selected the Taiwan preset, imported a BOM-prefixed TXT outside the container, converted it and exported through the system save panel. Export filename matched the source-derived default.
+- Read the saved file and compared exact bytes: BOM removed, CRLF/blank line/emoji/combining mark preserved, expected `鼠标 → 滑鼠` and `汉字 → 漢字` output.
+- Imported invalid UTF-8 through the real file panel: an error appeared and the previous input/result remained intact.
+- Closed/reopened the app window: preferences persisted and a fresh window model loaded without a crash.
+
+Build warnings observed were existing generated color-symbol collisions and the absence of AppIntents metadata; they were not changed as part of this feature work.
+
+## Release gates and dependency separation
+
+The app still pins the previously accepted SwiftyOpenCC revision. OpenCC 1.4.2 migration and its resource/ownership/compatibility checks live in a separate fork PR. Only after that PR is reviewed and merged, and the exact fork commit passes `OpenCC Compatibility`, may the coordinator propose an app dependency PR. Engine benchmark results are not claims about this app build.
+
+Before App Store release, verify purchase/cancellation/restore with a StoreKit sandbox account or TestFlight and verify the signed distribution build's Services/global-shortcut permissions and cross-app behavior. No real purchase was made. TestFlight/distribution signing and older physical devices are not covered by local Debug builds.

--- a/scripts/check-core.py
+++ b/scripts/check-core.py
@@ -36,11 +36,18 @@ with tempfile.TemporaryDirectory(prefix="openccman-core-") as directory:
     sources.mkdir(parents=True)
     for path in [
         root / "OpenCCman/Services/ChineseConversionService.swift",
+        root / "OpenCCman/Services/TextFileService.swift",
+        root / "OpenCCman/Model/ConversionConfiguration.swift",
+        root / "OpenCCman/Model/ConvertedTextDocument.swift",
+        root / "OpenCCman/Model/TestNumbersPerDayManager.swift",
         root / "OpenCCman/Scene/HomeViewModel.swift",
         root / "Tests/Regression/CoreSupport.swift",
         root / ("Tests/Benchmarks/ConversionBenchmark.swift" if args.benchmark else "Tests/Regression/CoreChecks.swift"),
     ]:
         shutil.copy2(path, sources / path.name)
+    if not args.benchmark:
+        shutil.copy2(root / "Tests/Regression/FileChecks.swift", sources / "FileChecks.swift")
+        shutil.copy2(root / "Tests/Regression/ProviderChecks.swift", sources / "ProviderChecks.swift")
     (package / "Package.swift").write_text('''// swift-tools-version: 5.9
 import PackageDescription
 let package = Package(
@@ -53,4 +60,4 @@ let package = Package(
     ])]
 )
 ''')
-    subprocess.run(["swift", "run", "-c", "release", "--package-path", str(package), "CoreChecks"], check=True)
+    subprocess.run(["swift", "run", "-c", "release", "--package-path", str(package), "CoreChecks"], check=True, timeout=600)

--- a/scripts/check-project.sh
+++ b/scripts/check-project.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+plutil -lint "$repo_root/OpenCCman.xcodeproj/project.pbxproj" \
+  "$repo_root/OpenCCman/Info.plist" \
+  "$repo_root/OpenCCman/OpenCCman.entitlements" \
+  "$repo_root/OpenCCman/PrivacyInfo.xcprivacy"
+
+while IFS= read -r -d '' source; do
+  xcrun swiftc -frontend -parse "$source"
+done < <(rg --files -0 -g '*.swift' "$repo_root/OpenCCman")
+
+while IFS= read -r -d '' localization; do
+  plutil -lint "$localization"
+done < <(rg --files -0 -g '*.strings' "$repo_root/OpenCCman")


### PR DESCRIPTION
为 1.3 增加四个常用转换预设和单个 TXT 文件导入、导出、拖放；沿用 iOS 14/macOS 11、现有偏好及付费规则。macOS Services、快捷键和主页使用同一配置映射。

Log:
- 需求描述：减少重复配置与复制粘贴，可靠处理文件取消/失败，并防止多个窗口同时消费最后一次免费额度。
- 实现思路：UTF-8/BOM、10 MiB 有界后台读取及权限成对释放；以任务标识拒绝迟到结果，导出保留成功快照；幂等额度预约在成功时扣次，取消/失败/释放时归还。
- 验证结果：真实核心/模型/文件/Provider 回归，额度 100 次并发及午夜边界，隔离剪贴板回归全部通过；完整 macOS/iOS 编译通过，未运行模拟器。
- 签名验收：独立测试 bundle 开启 App Sandbox，真实文件面板导入、转换、导出通过；逐字节确认 UTF-8 无 BOM，CRLF、Emoji、组合字符不丢失；错误文件保留原稿，窗口重开正常。

新增 App Regression CI。详细证据见 `docs/version-1.3-validation.md`。

引擎升级独立审阅：https://github.com/gewill/SwiftyOpenCC/pull/1 。此 PR 仍使用原锁定依赖，不引用待合并的引擎分支。发布前仍需 StoreKit sandbox/TestFlight 购买及签名发行版跨 App 权限验收；没有发起真实购买。
