### PR TITLE
建立两层 OpenCC 上游同步与人工合并自动化

### DIFF
--- a/.github/workflows/sync-opencc.yml
+++ b/.github/workflows/sync-opencc.yml
@@ -1,0 +1,182 @@
+name: Sync OpenCC
+
+on:
+  schedule:
+    - cron: '17 1 * * 1'
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - scripts/sync-upstream.py
+      - scripts/upstream-sync.json
+      - tests/test_upstream_sync.py
+      - .github/workflows/sync-opencc.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: opencc-upstream-sync
+  cancel-in-progress: false
+
+jobs:
+  coordinator-tests:
+    name: Upstream Coordinator Tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - run: python3 -m unittest discover -s tests -p 'test_*.py'
+
+  detect:
+    needs: coordinator-tests
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      stage: ${{ steps.detect.outputs.stage }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - name: Select the next dependency layer
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir detection
+          python3 scripts/sync-upstream.py check --stage fork > detection/fork.json
+          status=$(python3 -c 'import json; print(json.load(open("detection/fork.json"))["status"])')
+          if [ "$status" = changed ]; then
+            cp detection/fork.json detection/expected.json
+            echo 'stage=fork' >> "$GITHUB_OUTPUT"
+          elif [ "$status" = noop ]; then
+            python3 scripts/sync-upstream.py check --stage app > detection/app.json
+            status=$(python3 -c 'import json; print(json.load(open("detection/app.json"))["status"])')
+            if [ "$status" = changed ]; then
+              cp detection/app.json detection/expected.json
+              echo 'stage=app' >> "$GITHUB_OUTPUT"
+            fi
+          fi
+      - name: Detection summary
+        if: always()
+        shell: bash
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+          for path in sorted(Path('detection').glob('*.json')):
+              if path.name == 'expected.json':
+                  continue
+              data = json.loads(path.read_text())
+              print(f"- {data['stage']}: **{data['status']}** — {data.get('reason', 'update available')}")
+              if data.get('pr_url'):
+                  print(f"  {data['pr_url']}")
+          PY
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: detection
+          path: detection/
+          retention-days: 7
+
+  prepare:
+    needs: detect
+    if: needs.detect.outputs.stage != ''
+    runs-on: macos-15
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: detection
+          path: detection
+      - name: Build and validate without write credentials
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SYNC_STAGE: ${{ needs.detect.outputs.stage }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/sync-upstream.py prepare --stage "$SYNC_STAGE" --expected detection/expected.json --output candidate > preparation.json
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          data = json.loads(Path('preparation.json').read_text())
+          if data['status'] != 'changed' or not Path('candidate/candidate.json').exists():
+              raise SystemExit('Candidate no longer available; rerun after review/state change')
+          PY
+      - name: Preparation summary
+        if: always()
+        shell: bash
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+          path = Path('preparation.json')
+          if path.exists():
+              data = json.loads(path.read_text())
+              print(f"**{data['status']}**: {data.get('reason', 'Candidate validation passed')}")
+          report = Path('candidate/report.md')
+          if report.exists():
+              print(report.read_text())
+          PY
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: candidate
+          path: |
+            candidate/
+            preparation.json
+          retention-days: 7
+
+  publish:
+    needs: [detect, prepare]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: candidate
+          path: prepared
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        id: app-token
+        with:
+          app-id: ${{ vars.OPENCC_SYNC_APP_ID }}
+          private-key: ${{ secrets.OPENCC_SYNC_APP_PRIVATE_KEY }}
+          owner: gewill
+          repositories: ${{ needs.detect.outputs.stage == 'fork' && 'SwiftyOpenCC' || 'OpenCCman' }}
+          permission-contents: write
+          permission-pull-requests: write
+      - name: Publish the already validated commit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SYNC_STAGE: ${{ needs.detect.outputs.stage }}
+          OPENCC_SYNC_WRITE_REPOSITORY: ${{ needs.detect.outputs.stage == 'fork' && 'gewill/SwiftyOpenCC' || 'gewill/OpenCCman' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/sync-upstream.py pr --stage "$SYNC_STAGE" --prepared prepared/candidate > publication.json
+      - name: Publication summary
+        if: always()
+        shell: bash
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+          path = Path('publication.json')
+          if path.exists():
+              data = json.loads(path.read_text())
+              print(f"**{data['status']}**: {data.get('reason', 'PR prepared for human review')}")
+              if data.get('pr_url'):
+                  print(data['pr_url'])
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ fastlane/test_output
 
 iOSInjectionProject/
 **/.DS_Store
+
+# Local Python coordinator/test caches
+__pycache__/

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -1,0 +1,60 @@
+# OpenCC 上游同步
+
+协调器放在 **OpenCCman/main**，应用更新 PR 始终指向 **OpenCCman/build**；不需要把 main 的旧应用代码合入 build。每周一 UTC 01:17（台北 09:17）检测，也可手动运行 `Sync OpenCC`。它只开 PR，合并由维护者决定。
+
+## 首次启用
+
+1. 先人工合并 SwiftyOpenCC 的官方 `SimpleConverter`／JSON 配置迁移，使 fork/master 包含 `scripts/update-opencc-resources.py`、`Sources/OpenCC/Resources/manifest.json`（`schemaVersion=1`、`bridgeVersion=1`）与 `OpenCC Compatibility` CI。旧桥接不能仅替换子模块来升级。
+2. 让协调器进入 OpenCCman/main；让应用回归脚本与 `App Regression` CI 进入 build。两个 CI 的 **job 名称**也必须分别为 `OpenCC Compatibility`、`App Regression`。fork CI 必须测试 `push: master`，因为应用推广检查的是合并后的精确 SHA。
+3. 创建专用 GitHub App，仅安装至 `gewill/OpenCCman` 与 `gewill/SwiftyOpenCC`，仓库权限只选 **Contents: read/write、Pull requests: read/write**。不请求 Actions、Workflows、Administration 或自动批准权限。
+4. 在 OpenCCman 设置变量 `OPENCC_SYNC_APP_ID`、secret `OPENCC_SYNC_APP_PRIVATE_KEY`。这把私钥只传给发布 job；每次令牌仅允许写入当前目标仓库，任务结束撤销。App 私钥不进入检测／构建 job。写入另一公开仓库之外的来源与 check 信息用公开只读 API 获取，未扩大令牌权限。
+5. 给 fork/master、App/build 配置分支保护：要求 PR、相应 CI 成功、禁止 force-push。机器人不加入绕过列表。个人仓库单人维护时不强制另一位 reviewer，以免唯一维护者无法合并自己的人工 PR。
+
+GitHub 定时任务只从默认分支运行；公开仓库 60 天无活动会停用 schedule，定时运行也可能延迟，因此它不是可靠的定时提醒服务。[官方事件说明](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule)
+
+`GITHUB_TOKEN` 创建／更新 PR 所触发的 CI 当前需要人工批准，push 不触发后续 CI。本方案用 GitHub App 令牌发布候选，让普通 PR CI 自动启动，同时保留人工 merge。[令牌触发规则](https://docs.github.com/en/actions/concepts/security/github_token)、[App 权限](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/choosing-permissions-for-a-github-app)
+
+## 本地命令与两层流程
+
+需要 Python 3、Git、已登录的 `gh`；准备候选还需要 macOS、Xcode 命令行工具、Swift、CMake，以及 fork 资源脚本声明的构建工具。执行位置任意，脚本配置相对脚本定位。
+
+本地发布通过命令专用 `gh auth git-credential` 使用 `gh` 登录、`GH_TOKEN` 或 `GITHUB_TOKEN`，不改全局 Git 凭证设置。准备进程会移除显式 token 环境变量；本地运行仍可访问开发者原有 Git／钥匙串配置，它不是无凭证沙箱。Actions 的写入私钥和令牌只存在于独立发布 job。
+
+```sh
+python3 scripts/sync-upstream.py check --stage fork
+python3 scripts/sync-upstream.py prepare --stage fork
+python3 scripts/sync-upstream.py pr --stage fork
+```
+
+- `check` 读取远端状态；`prepare` 在独立临时 checkout 生成、测试候选，不 push。未传 `--output` 时创建持久临时目录，JSON 的 `artifact_directory` 返回路径。
+- 本地 `pr` 先准备、验证，然后发布。复用已验证产物可执行 `pr --stage fork --prepared /绝对路径/产物目录`；此路径完全不运行候选代码。Actions 强制使用此模式，把验证和写权限隔离。
+- 一次只推进一层。fork PR 人工 **Create a merge commit** 合入 master 后，再手动运行 workflow，或等下一次周检，才生成 App PR。也可把上述命令的 `--stage fork` 换为 `--stage app`。
+- App 只采用 fork/master 已合入且精确 SHA 上 `OpenCC Compatibility` 成功的版本；App/build 当前精确 SHA 也必须已有成功的 `App Regression`，发布前再核对两项。修改工程 requirement 为 revision，并更新 `Package.resolved` 中该 pin。执行 `xcodebuild -resolvePackageDependencies -skipPackageUpdates` 校验依赖解析，允许 Xcode 管理 `originHash`，但其他 pin／锁文件字段有任何变化立即失败，不提交。
+
+本机真实 build 分支临时 checkout 已验证从 branch 改为相同 revision 的解析路径：解析成功、其余 14 个 pin 未变、没有 Xcode Build。该证据覆盖解析方式，不代表未来升级一定兼容。
+
+## 同步规则与产物
+
+`scripts/upstream-sync.json` 定义两个目标、来源、检查名和回滚忽略清单。OpenCC 只选择公开正式 Release 中最大的 `ver.X.Y.Z`，排除 draft／prerelease；锁完整 SHA，拒绝已接纳 tag 改指向、降级和主版本自动跨越。wrapper 保持跟踪 `ddddxxx/SwiftyOpenCC/master`，保留现 fork 的本地修复。若 wrapper 涉及 workflow 改动，停止并交人工合并，不给机器人 `Workflows:write`。[Release API](https://docs.github.com/en/rest/releases/releases)、[fork 同步](https://docs.github.com/en/pull-requests/how-tos/work-with-forks/syncing-a-fork)
+
+每层最多一条待审 PR。候选标识由来源 SHA 确定，分支固定为 `codex/sync-fork-<id>` 或 `codex/sync-app-<id>`。同候选重试复用 PR；人工关闭但未合并的候选不自动重开；另一候选到达时有旧 PR 待审则等待。出现人工修改、远端 base 变化、合并冲突或非目标依赖漂移时停止，不覆盖或 force-push。
+
+相同来源与 base 的重新准备使用固定提交元数据，因此 push 成功、PR 创建失败后可以直接重跑并恢复。若在这两步之间 base 已前进，新候选与遗留分支必然不同，自动化会明确停止：先审查报告中的旧分支，确认没有 PR 或人工修改后由维护者删除该孤立分支，再重新运行；不能用 force-push 跳过这个检查。
+
+成功的 `prepare` 输出 `candidate.json`、`candidate.bundle`、`diff.patch`、`report.md`、`prepare.log`。发布再次核对 base、来源 SHA、bundle checksum 和变更范围，并从 bundle 推送经过验证的那个 commit。失败时保留 `failure.json`、报告、命令日志和可获得的 diff，随后删除隔离 checkout；失败候选不能发布。
+
+stdout 只输出一条 JSON；详细日志在 stderr／产物内。`status` 为 `noop`、`changed`、`waiting`、`blocked`、`error`。退出码：`0` 正常（包括无变化和等待），`2` 参数／迁移前置条件，`3` 冲突／策略阻断，`4` 验证失败，`5` 网络／认证失败。网络失败不解释为“没有更新”。
+
+无变化只用 Ubuntu；有候选才使用一个固定 macos-15 job。fork 执行资源生成、`--check`、`swift test`，App 执行锁定解析与 core／quota／pasteboard 回归；不启动模拟器或完整 App build。两仓库目前公开，标准 GitHub-hosted runner 免费，仍限制超时和并发以节省等待。[计费说明](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
+
+## 回滚与维护
+
+合并前直接关闭不接受的 PR。合并后先开 App PR 恢复原 revision；需要时再通过 Revert PR 撤销整个 fork 同步 merge（子模块、配置、字典及 manifest 一起恢复），不重写历史。把报告中的候选 id 加入 main 配置的 `ignoredCandidates.fork`／`ignoredCandidates.app`，防止被撤回的候选再次提出。新来源 SHA 会生成新 id，不受旧候选忽略影响。[GitHub 回滚 PR](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/reverting-a-pull-request)
+
+协调器源码／配置变更走 main PR，`Upstream Coordinator Tests` 在 Ubuntu 自动跑本地 Git 与假 GitHub 集成回归。手动复现：
+
+```sh
+python3 -m unittest discover -s tests -p 'test_*.py'
+```
+
+覆盖正常候选、PR 重试／POST 不确定结果、人工拒绝、同名外部 fork、冲突、移动 tag、降级／主版本、base 并发变化、bundle 篡改、测试失败产物、来源门禁、非目标 pin 漂移及验证进程无 token。测试只推送临时本地 fixture 仓库，不访问真实写入 API。

--- a/scripts/sync-upstream.py
+++ b/scripts/sync-upstream.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""Review-only OpenCC dependency updates. Never merges PRs or force-pushes.
+
+check reads remote state; prepare builds an isolated candidate. pr --prepared
+publishes a validated bundle; the local pr shortcut prepares one first.
+"""
+import argparse
+import base64
+import copy
+from contextlib import contextmanager
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+from urllib.parse import quote
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+SHA = re.compile(r"^[0-9a-f]{40}$")
+TAG = re.compile(r"^ver\.(\d+)\.(\d+)\.(\d+)$")
+MARKER = "<!-- opencc-sync:v1 "
+RUN_LOG = []
+
+
+class SyncError(Exception):
+    def __init__(self, message, code=3, **details):
+        super().__init__(message)
+        self.code, self.details = code, details
+
+
+def run(args, cwd=None, env=None, code=4):
+    result = subprocess.run(args, cwd=cwd, env=env, text=True,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    logged = f"$ {Path(args[0]).name}\n{result.stdout}\n{result.stderr}\n"
+    for key in ("GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"):
+        secret = (env or os.environ).get(key)
+        if secret:
+            logged = logged.replace(secret, "[REDACTED]")
+    RUN_LOG.append(logged)
+    if result.returncode:
+        # Never include environment values or credential-bearing commands.
+        detail = (result.stdout + "\n" + result.stderr).strip()[-6000:]
+        raise SyncError(f"{Path(args[0]).name} failed: {detail}", code)
+    if result.stderr:
+        print(result.stderr.rstrip(), file=sys.stderr)
+    return result.stdout.strip()
+
+
+def git(path, *args, **kwargs):
+    return run(["git", "-C", str(path), *args], **kwargs)
+
+
+def sha(value):
+    if not isinstance(value, str) or not SHA.fullmatch(value):
+        raise SyncError("Invalid full commit SHA", 2)
+    return value
+
+
+def version(tag):
+    match = TAG.fullmatch(tag)
+    if not match:
+        raise SyncError(f"Not a stable OpenCC tag: {tag}")
+    return tuple(map(int, match.groups()))
+
+
+class GitHub:
+    def public_api(self, endpoint, paginate=False):
+        """Read public sources without widening a publishing token's scope."""
+        url = "https://api.github.com/" + endpoint
+        pages = []
+        while url:
+            if not url.startswith("https://api.github.com/"):
+                raise SyncError("Unexpected public API pagination host", 5)
+            request = Request(url, headers={"Accept": "application/vnd.github+json",
+                                           "User-Agent": "opencc-upstream-sync"})
+            try:
+                with urlopen(request, timeout=30) as response:
+                    value = json.load(response)
+                    link = response.headers.get("Link", "")
+            except (HTTPError, URLError) as error:
+                raise SyncError(f"Public GitHub read failed: {error}", 5) from error
+            if not paginate:
+                return value
+            pages.extend(value)
+            next_link = re.search(r'<([^>]+)>; rel="next"', link)
+            url = next_link[1] if next_link else None
+        return pages
+
+    def api(self, endpoint, method="GET", body=None, paginate=False):
+        # A publish token is deliberately scoped to only its write destination.
+        # Other public repositories remain readable without granting it access.
+        destination = os.environ.get("OPENCC_SYNC_WRITE_REPOSITORY")
+        if method == "GET" and destination and not endpoint.startswith(f"repos/{destination}/"):
+            return self.public_api(endpoint, paginate)
+        args = ["gh", "api", endpoint, "--method", method]
+        if paginate:
+            args += ["--paginate", "--slurp"]
+        if body is None:
+            raw = run(args, code=5)
+        else:
+            # gh --input consumes a file, preserving literal text/newlines.
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as stream:
+                json.dump(body, stream)
+                stream.flush()
+                raw = run(args + ["--input", stream.name], code=5)
+        result = json.loads(raw) if raw else None
+        return [item for page in result for item in page] if paginate else result
+
+    def head(self, repo, ref):
+        return sha(self.api(f"repos/{repo}/commits/{quote(ref, safe='')}")["sha"])
+
+    def content(self, repo, path, ref):
+        data = self.api(f"repos/{repo}/contents/{quote(path)}?ref={quote(ref, safe='')}")
+        if "content" not in data or data.get("encoding") != "base64":
+            raise SyncError(f"Cannot read {repo}/{path}", 2)
+        return base64.b64decode(data["content"]).decode()
+
+    def pulls(self, repo, base):
+        return self.api(f"repos/{repo}/pulls?state=all&base={quote(base)}&per_page=100", paginate=True)
+
+    def tag_sha(self, repo, tag):
+        obj = self.api(f"repos/{repo}/git/ref/tags/{quote(tag, safe='')}")["object"]
+        for _ in range(8):
+            if obj["type"] == "commit":
+                return sha(obj["sha"])
+            if obj["type"] != "tag":
+                break
+            obj = self.api(f"repos/{repo}/git/tags/{sha(obj['sha'])}")["object"]
+        raise SyncError(f"Tag does not resolve to a commit: {tag}")
+
+    def compare(self, repo, base, head):
+        return self.api(f"repos/{repo}/compare/{sha(base)}...{sha(head)}")
+
+    def check_passed(self, repo, commit, name):
+        # Latest run of the named check wins; never accept an older green retry.
+        # Public checks need no token; the sync App does not need Checks:read.
+        pages = self.public_api(f"repos/{repo}/commits/{sha(commit)}/check-runs?filter=latest&per_page=100")
+        checks = [c for c in pages["check_runs"] if c["name"] == name
+                  and c.get("app", {}).get("slug") == "github-actions"
+                  and c.get("head_sha") == commit]
+        if not checks:
+            return False
+        latest = max(checks, key=lambda c: c["id"])
+        return latest["status"] == "completed" and latest["conclusion"] == "success"
+
+
+def candidate_id(stage, values):
+    return hashlib.sha256(json.dumps([stage, *values], separators=(",", ":")).encode()).hexdigest()[:20]
+
+
+def owned_pull(pr, stage, repo):
+    head = pr.get("head", {})
+    return (head.get("repo", {}).get("full_name") == repo
+            and head.get("ref", "").startswith(f"codex/sync-{stage}-")
+            and MARKER in (pr.get("body") or ""))
+
+
+def pull_gate(pulls, stage, repo, candidate=None):
+    pulls = [p for p in pulls if p.get("head", {}).get("repo", {}).get("full_name") == repo]
+    pending = [p for p in pulls if owned_pull(p, stage, repo) and p["state"] == "open"]
+    if pending:
+        return {"status": "waiting", "reason": "An update already awaits human review",
+                "pr_url": pending[0]["html_url"]}
+    if candidate:
+        branch = f"codex/sync-{stage}-{candidate}"
+        rejected = [p for p in pulls if p["head"]["ref"] == branch
+                    and p["state"] == "closed" and not p.get("merged_at")]
+        if rejected:
+            return {"status": "waiting", "reason": "This candidate was closed without merging; reopen it manually to retry",
+                    "pr_url": rejected[0]["html_url"]}
+    return None
+
+
+def discover(config, stage, github):
+    cfg = config[stage]
+    result = {"schemaVersion": 1, "stage": stage, "repository": cfg["repository"], "base": cfg["base"]}
+    pulls = github.pulls(cfg["repository"], cfg["base"])
+    gate = pull_gate(pulls, stage, cfg["repository"])
+    if gate:
+        return {**result, **gate}
+    base = github.head(cfg["repository"], cfg["base"])
+    result["base_sha"] = base
+    fork = config["fork"]
+    if stage == "fork":
+        try:
+            manifest = json.loads(github.content(cfg["repository"], cfg["manifest"], base))
+        except SyncError as error:
+            if "HTTP 404" in str(error):
+                raise SyncError("First merge the official SimpleConverter migration and resource manifest", 2) from error
+            raise
+        except ValueError as error:
+            raise SyncError("The accepted resource manifest is not valid JSON", 2) from error
+        if manifest.get("schemaVersion") != 1 or manifest.get("bridgeVersion") != 1:
+            raise SyncError("Unsupported bridge/manifest version; manual adapter review required", 2)
+        current = manifest["opencc"]
+        current_sha, current_tag = sha(current["revision"]), current["tag"]
+        if github.tag_sha(cfg["coreRepository"], current_tag) != current_sha:
+            raise SyncError(f"Previously accepted tag moved: {current_tag}")
+        releases = github.api(f"repos/{cfg['coreRepository']}/releases?per_page=100", paginate=True)
+        stable = [r for r in releases if not r["draft"] and not r["prerelease"] and TAG.fullmatch(r["tag_name"])]
+        if not stable:
+            raise SyncError("No published stable OpenCC release found")
+        target_tag = max(stable, key=lambda r: version(r["tag_name"]))["tag_name"]
+        old_version, new_version = version(current_tag), version(target_tag)
+        if new_version < old_version:
+            raise SyncError("Refusing an OpenCC downgrade")
+        if new_version[0] != old_version[0]:
+            raise SyncError("Major OpenCC upgrades require a manual compatibility migration")
+        target_sha = github.tag_sha(cfg["coreRepository"], target_tag)
+        upstream = github.head(cfg["upstreamRepository"], cfg["upstreamBase"])
+        comparison = github.compare(cfg["repository"], base, upstream)
+        incoming = comparison["status"] not in ("identical", "behind")
+        if incoming and any(f["filename"].startswith(".github/workflows/")
+                            or f.get("previous_filename", "").startswith(".github/workflows/")
+                            for f in comparison.get("files", [])):
+            raise SyncError("Upstream changes workflow files; review and merge those manually")
+        if not incoming and target_sha == current_sha:
+            return {**result, "status": "noop", "reason": "Wrapper and OpenCC are current"}
+        result.update(upstream_sha=upstream, old_core_sha=current_sha, core_sha=target_sha,
+                      old_core_tag=current_tag, core_tag=target_tag, incoming_wrapper=incoming)
+        candidate = candidate_id(stage, [upstream, target_sha])
+    else:
+        fork_state = discover(config, "fork", github)
+        if fork_state["status"] != "noop":
+            return {**result, "status": "waiting", "reason": "Finish the fork update before promoting it to the app",
+                    "fork_status": fork_state["status"], "pr_url": fork_state.get("pr_url")}
+        target_sha = github.head(fork["repository"], fork["base"])
+        pins = json.loads(github.content(cfg["repository"], cfg["resolved"], base))
+        pin = get_pin(pins)
+        old_sha = sha(pin["state"]["revision"])
+        if old_sha == target_sha:
+            return {**result, "status": "noop", "reason": "App already pins the accepted fork revision"}
+        if not github.check_passed(fork["repository"], target_sha, fork["requiredCheck"]):
+            return {**result, "status": "waiting", "reason": "Fork master needs a passing OpenCC Compatibility check",
+                    "fork_sha": target_sha}
+        if not github.check_passed(cfg["repository"], base, cfg["requiredCheck"]):
+            return {**result, "status": "waiting", "reason": "App build needs a passing App Regression check before a pin upgrade",
+                    "fork_sha": target_sha}
+        comparison = github.compare(fork["repository"], old_sha, target_sha)
+        if comparison["status"] != "ahead":
+            raise SyncError("Fork history diverged or moved backwards; review the app pin manually")
+        result.update(old_fork_sha=old_sha, fork_sha=target_sha)
+        candidate = candidate_id(stage, [target_sha])
+    result.update(candidate=candidate, branch=f"codex/sync-{stage}-{candidate}")
+    if candidate in config["ignoredCandidates"][stage]:
+        return {**result, "status": "noop", "reason": "Candidate explicitly ignored in reviewed configuration"}
+    gate = pull_gate(pulls, stage, cfg["repository"], candidate)
+    return {**result, **(gate or {"status": "changed"})}
+
+
+def get_pin(resolved):
+    pins = [p for p in resolved["pins"] if p["identity"] == "swiftyopencc"]
+    if len(pins) != 1:
+        raise SyncError("Expected exactly one SwiftyOpenCC pin", 2)
+    return pins[0]
+
+
+def pin_project(text, revision):
+    pattern = re.compile(r'(repositoryURL = "https://github\.com/gewill/SwiftyOpenCC(?:\.git)?";\s*requirement = \{)(.*?)(\n\s*\};)', re.S)
+    matches = list(pattern.finditer(text))
+    if len(matches) != 1:
+        raise SyncError("Expected exactly one SwiftyOpenCC project requirement", 2)
+    return pattern.sub(lambda m: m[1] + f"\n\t\t\t\tkind = revision;\n\t\t\t\trevision = {sha(revision)};" + m[3], text)
+
+
+def remote(repo):
+    # Fixture transport for hermetic integration tests; unset in Actions.
+    fixture = os.environ.get("OPENCC_SYNC_TEST_REMOTES")
+    return str(Path(fixture) / (repo + ".git")) if fixture else f"https://github.com/{repo}.git"
+
+
+def clone(repo, ref, path):
+    run(["git", "clone", "--no-checkout", "--branch", ref, remote(repo), str(path)], code=5)
+    git(path, "config", "user.name", "OpenCC Sync")
+    git(path, "config", "user.email", "opencc-sync@users.noreply.github.com")
+    git(path, "config", "commit.gpgsign", "false")
+
+
+def commit_environment(path, *refs, minimum=0):
+    # Re-preparing the same source inputs must recover the same bot branch after
+    # a successful push followed by an uncertain/failed PR creation request.
+    timestamp = max([minimum, *[int(git(path, "show", "-s", "--format=%ct", ref)) for ref in refs]])
+    return dict(os.environ, GIT_AUTHOR_DATE=f"{timestamp} +0000", GIT_COMMITTER_DATE=f"{timestamp} +0000")
+
+
+def push_candidate(path, head, branch):
+    # Reuse gh's environment/keychain authentication without exposing a token or
+    # modifying global Git configuration. Works with GH_TOKEN and GITHUB_TOKEN.
+    env = dict(os.environ, GIT_TERMINAL_PROMPT="0")
+    git(path, "-c", "credential.helper=", "-c", "credential.helper=!gh auth git-credential",
+        "push", "origin", f"{sha(head)}:refs/heads/{branch}", env=env, code=5)
+
+
+def verify_diff(config, data, path):
+    base, head = data["base_sha"], data["head_sha"]
+    changed = git(path, "diff", "--name-only", base, head).splitlines()
+    if not changed:
+        raise SyncError("Candidate contains no changes")
+    if any(p.startswith(".github/workflows/") for p in changed):
+        raise SyncError("Automatic publication of workflow changes is forbidden")
+    if data["stage"] == "app":
+        cfg = config["app"]
+        project = cfg["project"] + "/project.pbxproj"
+        if set(changed) - {project, cfg["resolved"]}:
+            raise SyncError("App candidate changes files outside its dependency pin")
+        before = git(path, "show", f"{base}:{project}")
+        after = git(path, "show", f"{head}:{project}")
+        if after != pin_project(before, data["fork_sha"]):
+            raise SyncError("App project changed outside SwiftyOpenCC requirement")
+        old = json.loads(git(path, "show", f"{base}:{cfg['resolved']}"))
+        new = json.loads(git(path, "show", f"{head}:{cfg['resolved']}"))
+        expected = copy.deepcopy(old)
+        get_pin(expected)["state"] = {"revision": data["fork_sha"]}
+        # Xcode owns originHash; all pins and other lockfile fields are invariant.
+        expected.pop("originHash", None)
+        new.pop("originHash", None)
+        if new != expected:
+            raise SyncError("Non-SwiftyOpenCC dependency drift detected")
+    else:
+        cfg = config["fork"]
+        if git(path, "rev-parse", f"{head}:{cfg['corePath']}") != data["core_sha"]:
+            raise SyncError("Candidate submodule SHA differs from the selected release")
+        manifest = json.loads(git(path, "show", f"{head}:{cfg['manifest']}"))
+        if manifest.get("opencc") != {"tag": data["core_tag"], "revision": data["core_sha"]}:
+            raise SyncError("Candidate resource manifest differs from its selected release")
+    git(path, "diff", "--check", base, head)
+
+
+def validate_candidate(config, data, path):
+    cfg = config[data["stage"]]
+    # CI injects no write credential here. Strip explicit token variables too;
+    # this is not a sandbox for a local developer's keychain/Git configuration.
+    clean = {k: v for k, v in os.environ.items() if k not in
+             {"GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"}}
+    if data["stage"] == "fork":
+        run(["python3", cfg["generator"]], cwd=path, env=clean)
+        run(["python3", cfg["generator"], "--check"], cwd=path, env=clean)
+        run(["swift", "test"], cwd=path, env=clean)
+    else:
+        run(["xcodebuild", "-resolvePackageDependencies", "-project", cfg["project"],
+             "-scheme", cfg["scheme"], "-skipPackageUpdates"], cwd=path, env=clean)
+        for command in (["python3", "scripts/check-core.py"], ["bash", "scripts/check-quota.sh"],
+                        ["bash", "scripts/check-pasteboard.sh"]):
+            run(command, cwd=path, env=clean)
+
+
+def report(data):
+    stage = data["stage"]
+    lines = [f"OpenCC {stage} update", "", f"Candidate: `{data['candidate']}`", "",
+             f"Base: `{data['repository']}:{data['base']}` at `{data['base_sha']}`", ""]
+    if stage == "fork":
+        lines += [f"Wrapper upstream: `{data['upstream_sha']}`",
+                  f"OpenCC: `{data['old_core_tag']}` / `{data['old_core_sha']}` → `{data['core_tag']}` / `{data['core_sha']}`"]
+    else:
+        lines += [f"SwiftyOpenCC: `{data['old_fork_sha']}` → `{data['fork_sha']}`"]
+    lines += ["", "Validation: " + ", ".join(data.get("checks", [])), "",
+              "Human review and merge required. Use **Create a merge commit** for fork updates.",
+              "To roll back, restore the app's prior pin in a PR; revert the complete fork update if needed.",
+              f"Add `{data['candidate']}` to `ignoredCandidates.{stage}` in the coordinator configuration to suppress this candidate.",
+              "", f"{MARKER}{stage} {data['candidate']} -->"]
+    return "\n".join(lines) + "\n"
+
+
+@contextmanager
+def candidate_workspace(output, data):
+    log_start = len(RUN_LOG)
+    with tempfile.TemporaryDirectory(prefix="opencc-sync-") as temp:
+        path = Path(temp) / "candidate"
+        try:
+            yield path
+        except Exception as error:
+            failure = {**data, "status": "blocked", "reason": str(error),
+                       "artifact_directory": str(output), **getattr(error, "details", {})}
+            (output / "failure.json").write_text(json.dumps(failure, ensure_ascii=False, indent=2) + "\n")
+            (output / "report.md").write_text(report(failure) + "\nFailure: " + str(error) + "\n")
+            if (path / ".git").exists():
+                result = subprocess.run(["git", "-C", str(path), "diff", "--binary", data["base_sha"]], text=True, capture_output=True)
+                (output / "diff.patch").write_text(result.stdout)
+            if isinstance(error, SyncError):
+                error.details["artifact_directory"] = str(output)
+            raise
+        finally:
+            (output / "prepare.log").write_text("\n".join(RUN_LOG[log_start:]))
+
+
+def prepare(config, stage, github, output, expected=None):
+    data = discover(config, stage, github)
+    if data["status"] != "changed":
+        return data
+    if expected and any(data.get(k) != expected.get(k) for k in
+                        ("stage", "base_sha", "candidate", "upstream_sha", "core_sha", "fork_sha")):
+        raise SyncError("Remote state changed since detection; run again")
+    output = Path(output).resolve()
+    if output.exists() and any(output.iterdir()):
+        raise SyncError("Output directory must be empty", 2)
+    output.mkdir(parents=True, exist_ok=True)
+    cfg = config[stage]
+    data["artifact_directory"] = str(output)
+    with candidate_workspace(output, data) as path:
+        clone(cfg["repository"], cfg["base"], path)
+        git(path, "checkout", "-b", data["branch"], data["base_sha"])
+        if stage == "fork":
+            git(path, "fetch", remote(cfg["upstreamRepository"]), cfg["upstreamBase"], code=5)
+            if git(path, "rev-parse", "FETCH_HEAD") != data["upstream_sha"]:
+                raise SyncError("Wrapper changed during preparation")
+            # Also reject workflow edits hidden by an incomplete compare API response.
+            commits = git(path, "log", "--format=%H", f"{data['base_sha']}..{data['upstream_sha']}", "--", ".github/workflows")
+            if commits:
+                raise SyncError("Incoming wrapper history changes workflows; merge manually")
+            if data["incoming_wrapper"]:
+                try:
+                    git(path, "merge", "--no-ff", "--no-edit", data["upstream_sha"], code=3,
+                        env=commit_environment(path, data["base_sha"], data["upstream_sha"]))
+                except SyncError as error:
+                    conflicts = git(path, "diff", "--name-only", "--diff-filter=U").splitlines()
+                    raise SyncError("Wrapper merge conflict; no branch was pushed", 3, conflicts=conflicts) from error
+            git(path, "submodule", "update", "--init", "--recursive", code=5)
+            core = path / cfg["corePath"]
+            git(core, "fetch", "origin", f"refs/tags/{data['core_tag']}", code=5)
+            if git(core, "rev-parse", "FETCH_HEAD^{commit}") != data["core_sha"]:
+                raise SyncError("OpenCC release tag moved during preparation")
+            git(core, "checkout", "--detach", data["core_sha"])
+        else:
+            resolved = path / cfg["resolved"]
+            pins = json.loads(resolved.read_text())
+            get_pin(pins)["state"] = {"revision": data["fork_sha"]}
+            resolved.write_text(json.dumps(pins, ensure_ascii=False, indent=2) + "\n")
+            project = path / cfg["project"] / "project.pbxproj"
+            project.write_text(pin_project(project.read_text(), data["fork_sha"]))
+        validate_candidate(config, data, path)
+        git(path, "add", "--all")
+        message = (f"chore: sync OpenCC {stage} ({data['candidate']})\n\n"
+                   "Log:\n需求描述: 同步已核验的 OpenCC 依赖。\n实现思路: 固定来源 SHA，生成并校验资源，经人工 PR 合并。")
+        core_time = int(git(path / cfg["corePath"], "show", "-s", "--format=%ct", data["core_sha"])) if stage == "fork" else 0
+        git(path, "commit", "-m", message, env=commit_environment(path, "HEAD", minimum=core_time))
+        data["head_sha"] = sha(git(path, "rev-parse", "HEAD"))
+        data["checks"] = (["resource generation", "manifest --check", "swift test"] if stage == "fork"
+                          else ["locked package resolution", "core", "quota", "pasteboard"])
+        verify_diff(config, data, path)
+        git(path, "bundle", "create", str(output / "candidate.bundle"), f"refs/heads/{data['branch']}", f"^{data['base_sha']}")
+        (output / "diff.patch").write_text(git(path, "diff", "--binary", data["base_sha"], data["head_sha"]) + "\n")
+    data["bundle_sha256"] = hashlib.sha256((output / "candidate.bundle").read_bytes()).hexdigest()
+    (output / "candidate.json").write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n")
+    (output / "report.md").write_text(report(data))
+    return data
+
+
+def publish(config, stage, github, prepared):
+    folder = Path(prepared).resolve()
+    data = json.loads((folder / "candidate.json").read_text())
+    cfg = config[stage]
+    if any(data.get(k) != value for k, value in
+           {"schemaVersion": 1, "stage": stage, "repository": cfg["repository"], "base": cfg["base"]}.items()):
+        raise SyncError("Prepared candidate/configuration mismatch", 2)
+    for key in ("base_sha", "head_sha", "upstream_sha", "core_sha") if stage == "fork" else ("base_sha", "head_sha", "fork_sha"):
+        sha(data[key])
+    expected_candidate = candidate_id(stage, [data["upstream_sha"], data["core_sha"]] if stage == "fork" else [data["fork_sha"]])
+    if data.get("candidate") != expected_candidate or data.get("branch") != f"codex/sync-{stage}-{expected_candidate}":
+        raise SyncError("Candidate identity mismatch")
+    if data["candidate"] in config["ignoredCandidates"][stage]:
+        return {**data, "status": "noop", "reason": "Candidate now ignored"}
+    bundle = folder / "candidate.bundle"
+    if hashlib.sha256(bundle.read_bytes()).hexdigest() != data["bundle_sha256"]:
+        raise SyncError("Candidate bundle checksum mismatch")
+    pulls = github.pulls(cfg["repository"], cfg["base"])
+    same = [p for p in pulls if p["head"]["ref"] == data["branch"]
+            and p["head"].get("repo", {}).get("full_name") == cfg["repository"]]
+    for pr in same:
+        if pr["state"] == "open":
+            if pr["head"]["sha"] != data["head_sha"]:
+                raise SyncError("The candidate PR was changed by another writer; leaving it untouched")
+            return {**data, "status": "waiting", "reason": "Candidate PR already exists", "pr_url": pr["html_url"]}
+        if pr.get("merged_at"):
+            return {**data, "status": "noop", "reason": "Candidate already merged", "pr_url": pr["html_url"]}
+    gate = pull_gate(pulls, stage, cfg["repository"], data["candidate"])
+    if gate:
+        return {**data, **gate}
+    if github.head(cfg["repository"], cfg["base"]) != data["base_sha"]:
+        raise SyncError("Target base changed after validation; prepare again")
+    if stage == "fork":
+        if github.tag_sha(cfg["coreRepository"], data["core_tag"]) != data["core_sha"]:
+            raise SyncError("Release tag moved after validation")
+    else:
+        fork = config["fork"]
+        if github.head(fork["repository"], fork["base"]) != data["fork_sha"]:
+            raise SyncError("Accepted fork changed after validation; prepare again")
+        if not github.check_passed(fork["repository"], data["fork_sha"], fork["requiredCheck"]):
+            raise SyncError("Fork compatibility check is no longer passing")
+        if not github.check_passed(cfg["repository"], data["base_sha"], cfg["requiredCheck"]):
+            raise SyncError("App base regression check is no longer passing")
+        if pull_gate(github.pulls(fork["repository"], fork["base"]), "fork", fork["repository"]):
+            raise SyncError("A fork update now awaits review; finish it first")
+    with tempfile.TemporaryDirectory(prefix="opencc-publish-") as temp:
+        path = Path(temp) / "candidate"
+        clone(cfg["repository"], cfg["base"], path)
+        git(path, "bundle", "verify", str(bundle))
+        git(path, "fetch", str(bundle), f"refs/heads/{data['branch']}")
+        if git(path, "rev-parse", "FETCH_HEAD") != data["head_sha"]:
+            raise SyncError("Bundle head differs from validated head")
+        git(path, "merge-base", "--is-ancestor", data["base_sha"], data["head_sha"], code=3)
+        verify_diff(config, data, path)
+        remote_heads = git(path, "ls-remote", "--heads", "origin", f"refs/heads/{data['branch']}", code=5)
+        if remote_heads and remote_heads.split()[0] != data["head_sha"]:
+            raise SyncError("Candidate branch already differs; force-push is forbidden. Inspect the existing branch; "
+                            "if it is an abandoned bot candidate without a PR or human changes, delete that branch "
+                            "manually before preparing again", 3, branch=data["branch"])
+        if not remote_heads:
+            push_candidate(path, data["head_sha"], data["branch"])
+        try:
+            pr = github.api(f"repos/{cfg['repository']}/pulls", method="POST", body={
+                "title": f"chore: sync OpenCC {stage} ({data.get('core_tag', data.get('fork_sha', '')[:12])})",
+                "head": data["branch"], "base": cfg["base"], "body": report(data)})
+        except SyncError:
+            # A previous uncertain POST or a concurrent publisher may have succeeded.
+            matches = [p for p in github.pulls(cfg["repository"], cfg["base"])
+                       if p["head"]["ref"] == data["branch"] and p["state"] == "open"
+                       and p["head"].get("repo", {}).get("full_name") == cfg["repository"]
+                       and p["head"]["sha"] == data["head_sha"]]
+            if not matches:
+                raise
+            pr = matches[0]
+    return {**data, "status": "changed", "pr_url": pr["html_url"]}
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["check", "prepare", "pr"])
+    parser.add_argument("--stage", required=True, choices=["fork", "app"])
+    parser.add_argument("--config", type=Path, default=Path(__file__).with_name("upstream-sync.json"))
+    parser.add_argument("--output", type=Path, help="Empty artifact directory; defaults to a persistent temporary directory")
+    parser.add_argument("--expected", type=Path, help="Detection JSON whose source SHAs must still match")
+    parser.add_argument("--prepared", type=Path, help="Publish validated artifacts without running candidate code (required in CI)")
+    args = parser.parse_args(argv)
+    code = 0
+    try:
+        config = json.loads(args.config.read_text())
+        if config.get("schemaVersion") != 1:
+            raise SyncError("Unsupported coordinator configuration", 2)
+        github = GitHub()
+        if args.command == "check":
+            data = discover(config, args.stage, github)
+        elif args.command == "prepare":
+            output = args.output or Path(tempfile.mkdtemp(prefix="opencc-candidate-"))
+            expected = json.loads(args.expected.read_text()) if args.expected else None
+            data = prepare(config, args.stage, github, output, expected)
+        else:
+            if not args.prepared:
+                if os.environ.get("GITHUB_ACTIONS") == "true":
+                    raise SyncError("CI pr requires --prepared; the publishing job must never build candidate code", 2)
+                output = args.output or Path(tempfile.mkdtemp(prefix="opencc-candidate-"))
+                data = prepare(config, args.stage, github, output)
+                if data["status"] == "changed":
+                    data = publish(config, args.stage, github, output)
+            else:
+                data = publish(config, args.stage, github, args.prepared)
+    except SyncError as error:
+        code = error.code
+        data = {"schemaVersion": 1, "stage": args.stage,
+                "status": "blocked" if code in (2, 3, 4) else "error",
+                "reason": str(error), **error.details}
+    except (OSError, ValueError, KeyError, TypeError) as error:
+        code = 2
+        data = {"schemaVersion": 1, "stage": args.stage, "status": "error", "reason": str(error)}
+    print(json.dumps(data, ensure_ascii=False, sort_keys=True))
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/upstream-sync.json
+++ b/scripts/upstream-sync.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": 1,
+  "fork": {
+    "repository": "gewill/SwiftyOpenCC",
+    "base": "master",
+    "upstreamRepository": "ddddxxx/SwiftyOpenCC",
+    "upstreamBase": "master",
+    "coreRepository": "BYVoid/OpenCC",
+    "corePath": "OpenCC",
+    "manifest": "Sources/OpenCC/Resources/manifest.json",
+    "generator": "scripts/update-opencc-resources.py",
+    "requiredCheck": "OpenCC Compatibility"
+  },
+  "app": {
+    "repository": "gewill/OpenCCman",
+    "base": "build",
+    "project": "OpenCCman.xcodeproj",
+    "scheme": "OpenCCman",
+    "resolved": "OpenCCman.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved",
+    "requiredCheck": "App Regression"
+  },
+  "ignoredCandidates": {
+    "fork": [],
+    "app": []
+  }
+}

--- a/tests/test_upstream_sync.py
+++ b/tests/test_upstream_sync.py
@@ -1,0 +1,446 @@
+"""Integration coverage using disposable Git repositories and a fake GitHub API.
+
+No remote pushes, Xcode builds, Swift compilation, or real credentials are used.
+"""
+import copy
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import shutil
+import time
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/sync-upstream.py"
+spec = importlib.util.spec_from_file_location("sync_upstream", SCRIPT)
+sync = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sync)
+CONFIG = json.loads(SCRIPT.with_name("upstream-sync.json").read_text())
+
+
+def command(path, *args):
+    return subprocess.check_output(["git", "-C", str(path), *args], text=True, stderr=subprocess.DEVNULL).strip()
+
+
+class FakeGitHub:
+    def __init__(self, root, config):
+        self.root, self.config = root, config
+        self.prs = {config[s]["repository"]: [] for s in ("fork", "app")}
+        self.releases = [{"tag_name": t, "draft": False, "prerelease": False}
+                         for t in ("ver.1.4.1", "ver.1.4.2")]
+        self.green = True
+        self.green_checks = {}
+        self.post_failure = False
+        self.posts = 0
+
+    def repo(self, repo):
+        return self.root / (repo + ".git")
+
+    def head(self, repo, ref):
+        return command(self.repo(repo), "rev-parse", ref)
+
+    def tag_sha(self, repo, tag):
+        return command(self.repo(repo), "rev-parse", tag + "^{commit}")
+
+    def content(self, repo, path, ref):
+        return command(self.repo(repo), "show", f"{ref}:{path}")
+
+    def pulls(self, repo, base):
+        return copy.deepcopy(self.prs[repo])
+
+    def check_passed(self, repo, commit, name):
+        return self.green_checks.get(name, self.green)
+
+    def compare(self, repo, base, head):
+        path = self.repo(repo)
+        if base == head:
+            status = "identical"
+        else:
+            # Ensure the fork can inspect commits from its local upstream network.
+            if repo == self.config["fork"]["repository"]:
+                command(path, "fetch", str(self.repo(self.config["fork"]["upstreamRepository"])), "master")
+            try:
+                command(path, "merge-base", "--is-ancestor", head, base)
+                status = "behind"
+            except subprocess.CalledProcessError:
+                try:
+                    command(path, "merge-base", "--is-ancestor", base, head)
+                    status = "ahead"
+                except subprocess.CalledProcessError:
+                    status = "diverged"
+        files = command(path, "diff", "--name-only", f"{base}...{head}").splitlines()
+        return {"status": status, "files": [{"filename": p} for p in files]}
+
+    def api(self, endpoint, method="GET", body=None, paginate=False):
+        if "/releases?" in endpoint:
+            return self.releases
+        if method == "POST" and endpoint.endswith("/pulls"):
+            self.posts += 1
+            repo = endpoint[len("repos/"):-len("/pulls")]
+            pr = {"head": {"ref": body["head"], "sha": self.head(repo, body["head"]), "repo": {"full_name": repo}},
+                  "state": "open", "merged_at": None, "body": body["body"],
+                  "html_url": "https://example.test/pull/1"}
+            self.prs[repo].append(pr)
+            if self.post_failure:
+                raise sync.SyncError("connection lost after successful POST", 5)
+            return pr
+        raise AssertionError(endpoint)
+
+
+class SyncIntegrationTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="sync-tests-")
+        self.root = Path(self.temp.name)
+        self.config = copy.deepcopy(CONFIG)
+        self.env = patch.dict(os.environ, {"OPENCC_SYNC_TEST_REMOTES": str(self.root), "GIT_ALLOW_PROTOCOL": "file:https:http"})
+        self.env.start()
+        self.github = FakeGitHub(self.root, self.config)
+        core = self.init(self.config["fork"]["coreRepository"])
+        self.write_commit(core, "data.txt", "old\n")
+        command(core, "tag", "ver.1.4.1")
+        self.old_core = command(core, "rev-parse", "HEAD")
+        self.write_commit(core, "data.txt", "new\n")
+        command(core, "tag", "-a", "ver.1.4.2", "-m", "stable release")
+        self.new_core = command(core, "rev-parse", "HEAD")
+        upstream = self.init(self.config["fork"]["upstreamRepository"])
+        self.write_commit(upstream, "wrapper.swift", "initial\n")
+        fork = self.github.repo(self.config["fork"]["repository"])
+        fork.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "clone", str(upstream), str(fork)], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.identity(fork)
+        command(fork, "submodule", "add", str(core), "OpenCC")
+        command(fork / "OpenCC", "checkout", self.old_core)
+        manifest = fork / self.config["fork"]["manifest"]
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(json.dumps({"schemaVersion": 1, "bridgeVersion": 1,
+                                       "opencc": {"tag": "ver.1.4.1", "revision": self.old_core}}))
+        command(fork, "add", ".")
+        command(fork, "commit", "-m", "fork baseline")
+        self.fork = fork
+        self.old_fork = command(fork, "rev-parse", "HEAD")
+        app = self.init(self.config["app"]["repository"], "build")
+        project = app / self.config["app"]["project"] / "project.pbxproj"
+        project.parent.mkdir(parents=True)
+        project.write_text('repositoryURL = "https://github.com/gewill/SwiftyOpenCC";\nrequirement = {\nbranch = master;\nkind = branch;\n};\n')
+        lock = app / self.config["app"]["resolved"]
+        lock.parent.mkdir(parents=True)
+        lock.write_text(json.dumps({"version": 3, "originHash": "old-hash", "pins": [
+            {"identity": "swiftyopencc", "state": {"branch": "master", "revision": self.old_fork}},
+            {"identity": "another-dependency", "state": {"version": "1.0.0", "revision": "1" * 40}}]}))
+        command(app, "add", ".")
+        command(app, "commit", "-m", "app baseline")
+        self.app = app
+
+    def tearDown(self):
+        self.env.stop()
+        self.temp.cleanup()
+
+    def identity(self, path):
+        command(path, "config", "user.name", "Fixture")
+        command(path, "config", "user.email", "fixture@example.test")
+
+    def init(self, repo, branch="master"):
+        path = self.github.repo(repo)
+        path.mkdir(parents=True)
+        command(path, "init", "-b", branch)
+        self.identity(path)
+        return path
+
+    def write_commit(self, path, name, text):
+        target = path / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text)
+        command(path, "add", ".")
+        command(path, "commit", "-m", "fixture change")
+
+    def validator(self, config, data, path):
+        # Simulates the independent generator/compiler boundary; the Git merge,
+        # clone, submodule checkout, lockfile edit, bundle and publish are real.
+        if data["stage"] == "fork":
+            manifest = path / config["fork"]["manifest"]
+            value = json.loads(manifest.read_text())
+            value["opencc"] = {"tag": data["core_tag"], "revision": data["core_sha"]}
+            manifest.write_text(json.dumps(value))
+        else:
+            lock = path / config["app"]["resolved"]
+            value = json.loads(lock.read_text())
+            value["originHash"] = "resolver-updated"
+            lock.write_text(json.dumps(value))
+
+    def prepare(self, stage="fork"):
+        output = self.root / f"artifacts-{stage}"
+        with patch.object(sync, "validate_candidate", side_effect=self.validator):
+            data = sync.prepare(self.config, stage, self.github, output)
+        return data, output
+
+    def accept_core(self):
+        command(self.fork / "OpenCC", "checkout", self.new_core)
+        manifest = self.fork / self.config["fork"]["manifest"]
+        data = json.loads(manifest.read_text())
+        data["opencc"] = {"tag": "ver.1.4.2", "revision": self.new_core}
+        self.write_commit(self.fork, self.config["fork"]["manifest"], json.dumps(data))
+
+    def pull(self, stage, candidate, state="open", merged=False):
+        return {"head": {"ref": f"codex/sync-{stage}-{candidate}", "sha": "f" * 40,
+                         "repo": {"full_name": self.config[stage]["repository"]}},
+                "state": state, "merged_at": "today" if merged else None,
+                "body": f"{sync.MARKER}{stage} {candidate} -->", "html_url": "https://example.test/pull/1"}
+
+    def test_prepare_and_publish_bundle_preserve_base_and_retry_without_duplicate(self):
+        base = command(self.fork, "rev-parse", "master")
+        data, output = self.prepare()
+        self.assertEqual(command(self.fork, "rev-parse", "master"), base)
+        self.assertTrue((output / "diff.patch").exists())
+        first = sync.publish(self.config, "fork", self.github, output)
+        second = sync.publish(self.config, "fork", self.github, output)
+        self.assertEqual(first["pr_url"], second["pr_url"])
+        self.assertEqual(second["status"], "waiting")
+        self.assertEqual(self.github.posts, 1)
+        self.assertEqual(command(self.fork, "rev-parse", "master"), base)
+        self.assertEqual(command(self.fork, "rev-parse", data["branch"]), data["head_sha"])
+
+    def test_uncertain_post_is_reconciled(self):
+        _, output = self.prepare()
+        self.github.post_failure = True
+        result = sync.publish(self.config, "fork", self.github, output)
+        self.assertEqual(result["pr_url"], "https://example.test/pull/1")
+        self.assertEqual(self.github.posts, 1)
+
+    def test_reprepare_recovers_identical_commit_after_push_without_pr(self):
+        first, output = self.prepare()
+        with patch.object(self.github, "api", side_effect=sync.SyncError("POST unavailable", 5)):
+            with self.assertRaises(sync.SyncError):
+                sync.publish(self.config, "fork", self.github, output)
+        self.assertEqual(self.github.head(self.config["fork"]["repository"], first["branch"]), first["head_sha"])
+        time.sleep(1.05)  # Proves wall-clock commit time cannot change the retry SHA.
+        retry = self.root / "retry-artifacts"
+        with patch.object(sync, "validate_candidate", side_effect=self.validator):
+            second = sync.prepare(self.config, "fork", self.github, retry)
+        self.assertEqual(first["head_sha"], second["head_sha"])
+        self.assertEqual(sync.publish(self.config, "fork", self.github, retry)["status"], "changed")
+
+    def test_noop_and_ignored_candidate(self):
+        state = sync.discover(self.config, "fork", self.github)
+        self.config["ignoredCandidates"]["fork"].append(state["candidate"])
+        self.assertEqual(sync.discover(self.config, "fork", self.github)["status"], "noop")
+        self.accept_core()
+        self.assertEqual(sync.discover(self.config, "fork", self.github)["status"], "noop")
+
+    def test_pr_wait_and_human_rejection(self):
+        candidate = sync.discover(self.config, "fork", self.github)["candidate"]
+        repo = self.config["fork"]["repository"]
+        for state in ("open", "closed"):
+            self.github.prs[repo] = [self.pull("fork", candidate, state)]
+            self.assertEqual(sync.discover(self.config, "fork", self.github)["status"], "waiting")
+
+    def test_move_downgrade_major_and_prerelease_policies(self):
+        core = self.github.repo(self.config["fork"]["coreRepository"])
+        command(core, "tag", "-f", "ver.1.4.1", self.new_core)
+        with self.assertRaisesRegex(sync.SyncError, "tag moved"):
+            sync.discover(self.config, "fork", self.github)
+        command(core, "tag", "-f", "ver.1.4.1", self.old_core)
+        self.github.releases = [{"tag_name": "ver.1.4.0", "draft": False, "prerelease": False}]
+        with self.assertRaisesRegex(sync.SyncError, "downgrade"):
+            sync.discover(self.config, "fork", self.github)
+        self.github.releases[0]["tag_name"] = "ver.2.0.0"
+        with self.assertRaisesRegex(sync.SyncError, "Major"):
+            sync.discover(self.config, "fork", self.github)
+        self.github.releases += [{"tag_name": "ver.1.4.2", "draft": False, "prerelease": False}]
+        self.github.releases[0]["prerelease"] = True
+        self.assertEqual(sync.discover(self.config, "fork", self.github)["core_tag"], "ver.1.4.2")
+
+    def test_workflow_change_blocked(self):
+        upstream = self.github.repo(self.config["fork"]["upstreamRepository"])
+        self.write_commit(upstream, ".github/workflows/new.yml", "name: incoming\n")
+        with self.assertRaisesRegex(sync.SyncError, "workflow"):
+            sync.discover(self.config, "fork", self.github)
+
+    def test_merge_conflict_does_not_publish(self):
+        upstream = self.github.repo(self.config["fork"]["upstreamRepository"])
+        self.write_commit(upstream, "wrapper.swift", "upstream incompatible\n")
+        self.write_commit(self.fork, "wrapper.swift", "local patch\n")
+        with self.assertRaises(sync.SyncError) as context:
+            self.prepare()
+        self.assertEqual(context.exception.code, 3)
+        self.assertEqual(context.exception.details["conflicts"], ["wrapper.swift"])
+        self.assertEqual(self.github.posts, 0)
+
+    def test_base_change_and_changed_bot_branch_block_publication(self):
+        data, output = self.prepare()
+        self.write_commit(self.fork, "after.swift", "human change\n")
+        with self.assertRaisesRegex(sync.SyncError, "base changed"):
+            sync.publish(self.config, "fork", self.github, output)
+        command(self.fork, "reset", "--hard", data["base_sha"])
+        command(self.fork, "branch", data["branch"], data["base_sha"])
+        with self.assertRaisesRegex(sync.SyncError, "force-push"):
+            sync.publish(self.config, "fork", self.github, output)
+
+    def test_corrupt_bundle_is_rejected(self):
+        _, output = self.prepare()
+        with (output / "candidate.bundle").open("ab") as stream:
+            stream.write(b"corruption")
+        with self.assertRaisesRegex(sync.SyncError, "checksum"):
+            sync.publish(self.config, "fork", self.github, output)
+
+    def test_failed_validation_creates_no_publishable_bundle(self):
+        output = self.root / "failed"
+        with patch.object(sync, "validate_candidate", side_effect=sync.SyncError("fixture test failed", 4)):
+            with self.assertRaises(sync.SyncError) as context:
+                sync.prepare(self.config, "fork", self.github, output)
+        self.assertEqual(context.exception.code, 4)
+        self.assertFalse((output / "candidate.bundle").exists())
+        self.assertTrue((output / "failure.json").exists())
+        self.assertTrue((output / "prepare.log").exists())
+        self.assertTrue((output / "diff.patch").exists())
+
+    def test_external_fork_same_named_pr_does_not_block(self):
+        candidate = sync.discover(self.config, "fork", self.github)["candidate"]
+        pr = self.pull("fork", candidate)
+        pr["head"]["repo"]["full_name"] = "other/SwiftyOpenCC"
+        self.github.prs[self.config["fork"]["repository"]] = [pr]
+        self.assertEqual(sync.discover(self.config, "fork", self.github)["status"], "changed")
+
+    def test_app_waits_for_fork_and_exact_sha_check_then_updates_only_pin(self):
+        self.assertEqual(sync.discover(self.config, "app", self.github)["status"], "waiting")
+        self.accept_core()
+        self.github.green = False
+        self.assertEqual(sync.discover(self.config, "app", self.github)["status"], "waiting")
+        self.github.green = True
+        data, output = self.prepare("app")
+        result = sync.publish(self.config, "app", self.github, output)
+        self.assertEqual(result["status"], "changed")
+        lock = json.loads(command(self.app, "show", f"{data['head_sha']}:{self.config['app']['resolved']}"))
+        self.assertEqual(sync.get_pin(lock)["state"], {"revision": data["fork_sha"]})
+        self.assertEqual(lock["pins"][1]["state"]["version"], "1.0.0")
+
+    def test_other_dependency_drift_is_rejected(self):
+        self.accept_core()
+        def drift(config, data, path):
+            self.validator(config, data, path)
+            lock = path / config["app"]["resolved"]
+            value = json.loads(lock.read_text())
+            value["pins"][1]["state"]["version"] = "2.0.0"
+            lock.write_text(json.dumps(value))
+        with patch.object(sync, "validate_candidate", side_effect=drift):
+            with self.assertRaisesRegex(sync.SyncError, "dependency drift"):
+                sync.prepare(self.config, "app", self.github, self.root / "drift")
+
+    def test_app_base_ci_must_pass_before_preparation_and_publication(self):
+        self.accept_core()
+        self.github.green_checks["App Regression"] = False
+        state = sync.discover(self.config, "app", self.github)
+        self.assertEqual(state["status"], "waiting")
+        self.assertIn("App Regression", state["reason"])
+        self.github.green_checks["App Regression"] = True
+        _, output = self.prepare("app")
+        self.github.green_checks["App Regression"] = False
+        with self.assertRaisesRegex(sync.SyncError, "App base regression"):
+            sync.publish(self.config, "app", self.github, output)
+        self.assertEqual(self.github.posts, 0)
+
+    def test_expected_discovery_detects_races(self):
+        expected = sync.discover(self.config, "fork", self.github)
+        self.write_commit(self.fork, "new.swift", "human\n")
+        with self.assertRaisesRegex(sync.SyncError, "changed since detection"):
+            sync.prepare(self.config, "fork", self.github, self.root / "race", expected)
+
+    def test_cli_fake_gh_returns_json_and_network_exit_code(self):
+        binary = self.root / "bin"
+        binary.mkdir()
+        fake = binary / "gh"
+        fake.write_text('#!/bin/sh\nprintf "%s\\n" "fixture network failure" >&2\nexit 1\n')
+        fake.chmod(0o755)
+        env = dict(os.environ, PATH=str(binary) + os.pathsep + os.environ["PATH"])
+        result = subprocess.run(["python3", str(SCRIPT), "check", "--stage", "fork"], env=env,
+                                text=True, capture_output=True)
+        self.assertEqual(result.returncode, 5)
+        self.assertEqual(json.loads(result.stdout)["status"], "error")
+
+    def test_manifest_network_failure_is_not_misreported_as_missing_migration(self):
+        with patch.object(self.github, "content", side_effect=sync.SyncError("network timeout", 5)):
+            with self.assertRaises(sync.SyncError) as context:
+                sync.discover(self.config, "fork", self.github)
+        self.assertEqual(context.exception.code, 5)
+        self.assertIn("network timeout", str(context.exception))
+
+    def test_bare_prepare_returns_persistent_artifact_path(self):
+        stdout = io.StringIO()
+        with patch.object(sync, "GitHub", return_value=self.github), patch.object(sync, "validate_candidate", side_effect=self.validator):
+            with patch("sys.stdout", stdout):
+                code = sync.main(["prepare", "--stage", "fork"])
+        data = json.loads(stdout.getvalue())
+        try:
+            self.assertEqual(code, 0)
+            self.assertTrue((Path(data["artifact_directory"]) / "candidate.bundle").exists())
+        finally:
+            shutil.rmtree(data["artifact_directory"])
+
+    def test_bare_local_pr_prepares_and_publishes_but_ci_requires_artifact(self):
+        stdout = io.StringIO()
+        with patch.dict(os.environ, {"GITHUB_ACTIONS": "false"}):
+            with patch.object(sync, "GitHub", return_value=self.github), patch.object(sync, "validate_candidate", side_effect=self.validator):
+                with patch("sys.stdout", stdout):
+                    code = sync.main(["pr", "--stage", "fork"])
+        data = json.loads(stdout.getvalue())
+        try:
+            self.assertEqual(code, 0)
+            self.assertEqual(self.github.posts, 1)
+        finally:
+            shutil.rmtree(data["artifact_directory"])
+        stdout = io.StringIO()
+        with patch.dict(os.environ, {"GITHUB_ACTIONS": "true"}), patch("sys.stdout", stdout):
+            code = sync.main(["pr", "--stage", "fork"])
+        self.assertEqual(code, 2)
+        self.assertIn("must never build", json.loads(stdout.getvalue())["reason"])
+
+    def test_latest_exact_commit_check_must_be_green(self):
+        github = sync.GitHub()
+        commit = "a" * 40
+        checks = {"check_runs": [
+            {"name": "OpenCC Compatibility", "app": {"slug": "github-actions"},
+             "head_sha": commit, "status": "completed", "conclusion": "success", "id": 1},
+            {"name": "OpenCC Compatibility", "app": {"slug": "github-actions"},
+             "head_sha": commit, "status": "completed", "conclusion": "failure", "id": 2}]}
+        with patch.object(github, "public_api", return_value=checks):
+            self.assertFalse(github.check_passed("fixture/repo", commit, "OpenCC Compatibility"))
+        checks["check_runs"][1]["head_sha"] = "b" * 40
+        with patch.object(github, "public_api", return_value=checks):
+            self.assertTrue(github.check_passed("fixture/repo", commit, "OpenCC Compatibility"))
+
+    def test_git_credential_protocol_accepts_github_token_or_persistent_gh_login(self):
+        binary = self.root / "credential-bin"
+        binary.mkdir()
+        fake = binary / "gh"
+        fake.write_text('#!/usr/bin/env python3\nimport os,sys\n'
+                        'assert sys.argv[1:] == ["auth", "git-credential", "get"]\n'
+                        'print("username=x-access-token")\n'
+                        'print("password=" + os.environ.get("GITHUB_TOKEN", "fixture-persistent-login"))\n')
+        fake.chmod(0o755)
+        for token in ("fixture-github-token", None):
+            env = dict(os.environ, PATH=str(binary) + os.pathsep + os.environ["PATH"])
+            env.pop("GH_TOKEN", None)
+            env.pop("GITHUB_TOKEN", None)
+            if token:
+                env["GITHUB_TOKEN"] = token
+            result = subprocess.run(["git", "-c", "credential.helper=", "-c",
+                                     "credential.helper=!gh auth git-credential", "credential", "fill"],
+                                    input="protocol=https\nhost=github.com\n\n", text=True,
+                                    capture_output=True, env=env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("password=" + (token or "fixture-persistent-login"), result.stdout)
+
+    def test_validation_subprocesses_receive_no_tokens(self):
+        commands = []
+        with patch.dict(os.environ, {"GH_TOKEN": "fixture-secret", "GITHUB_TOKEN": "fixture-secret"}):
+            with patch.object(sync, "run", side_effect=lambda args, **kwargs: commands.append(kwargs["env"])):
+                sync.validate_candidate(self.config, {"stage": "fork"}, self.root)
+        self.assertEqual(len(commands), 3)
+        self.assertTrue(all("GH_TOKEN" not in e and "GITHUB_TOKEN" not in e for e in commands))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
协调器在 `main` 定期检测 wrapper 提交和 OpenCC 正式 Release，先为 SwiftyOpenCC 创建同步 PR；维护者合并且精确 SHA 的 CI 成功后，再向应用 `build` 创建依赖 revision 更新 PR。

实现 `check`／`prepare`／`pr` 三种接口，隔离 checkout、来源与资源锁定、候选重试、人工拒绝记录、冲突停止及其他依赖漂移检测。验证和发布分属不同 job，只有发布 job 使用权限限定的 GitHub App 短期令牌；所有 Action 固定完整 SHA。

### Log

- 需求：建立可审查、可重复执行的两层上游同步流程，避免直接更新子模块、污染开发目录或重复开 PR。
- 实现：每周一台北 09:17 检查，也可手动执行；候选生成补丁、来源清单、校验和与日志；不自动合并，不强制推送，回滚候选可显式忽略。
- 验证：23 项本地 Git／模拟 GitHub 集成测试通过，覆盖重复发布、待审／人工关闭 PR、冲突、生成失败、移动 tag、权限失败、依赖漂移和产物篡改。真实隔离应用 checkout 已验证 revision 解析，其余 14 个依赖 pin 不变。
- 部署配置：专用 GitHub App `openccman-upstream-sync` 已安装，范围仅为 OpenCCman 和 SwiftyOpenCC；变量与私钥 Secret 已设置。分别签发单仓库令牌，验证仓库范围与 Contents／Pull requests 读写权限后即时撤销测试令牌。验证 job 不持有 App 私钥。
- 合并门槛：应用 `build` 与引擎 `master` 已要求 PR、对应 GitHub Actions 检查通过、分支最新，禁止强制推送；管理员也受约束。单人维护不强制另一位 reviewer。
- 远端 CI：`Upstream Coordinator Tests` 已通过，23 项测试；PR 事件按设计跳过检测、准备与发布。
- 剩余启用前置：人工合入引擎兼容迁移、应用功能／CI，以及本 PR。定时任务只在本 PR 进入默认分支后生效。当前旧引擎会返回明确的迁移前置阻断。

关联：gewill/SwiftyOpenCC#1、#2。配置和人工合并／回滚步骤见 `docs/upstream-sync.md`。
