### PR TITLE
fix: authenticate public API reads in upstream sync

### DIFF
--- a/.github/workflows/sync-opencc.yml
+++ b/.github/workflows/sync-opencc.yml
@@ -29,6 +29,28 @@ jobs:
         with:
           persist-credentials: false
       - run: python3 -m unittest discover -s tests -p 'test_*.py'
+      - name: Verify read token on public check APIs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_READ_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import importlib.util
+          import json
+          from pathlib import Path
+          path = Path('scripts/sync-upstream.py')
+          spec = importlib.util.spec_from_file_location('sync_upstream', path)
+          module = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(module)
+          config = json.loads(path.with_name('upstream-sync.json').read_text())
+          for stage in ('fork', 'app'):
+              target = config[stage]
+              response = module.GitHub().api(f"repos/{target['repository']}/commits/{target['base']}/check-runs?per_page=1")
+              if not isinstance(response.get('check_runs'), list):
+                  raise SystemExit(f"Cannot read public checks for {target['repository']}")
+              print(f"Read token verified: {target['repository']}")
+          PY
 
   detect:
     needs: coordinator-tests
@@ -160,8 +182,8 @@ jobs:
       - name: Publish the already validated commit
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_READ_TOKEN: ${{ github.token }}
           SYNC_STAGE: ${{ needs.detect.outputs.stage }}
-          OPENCC_SYNC_WRITE_REPOSITORY: ${{ needs.detect.outputs.stage == 'fork' && 'gewill/SwiftyOpenCC' || 'gewill/OpenCCman' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -7,7 +7,7 @@
 1. 先人工合并 SwiftyOpenCC 的官方 `SimpleConverter`／JSON 配置迁移，使 fork/master 包含 `scripts/update-opencc-resources.py`、`Sources/OpenCC/Resources/manifest.json`（`schemaVersion=1`、`bridgeVersion=1`）与 `OpenCC Compatibility` CI。旧桥接不能仅替换子模块来升级。
 2. 让协调器进入 OpenCCman/main；让应用回归脚本与 `App Regression` CI 进入 build。两个 CI 的 **job 名称**也必须分别为 `OpenCC Compatibility`、`App Regression`。fork CI 必须测试 `push: master`，因为应用推广检查的是合并后的精确 SHA。
 3. 创建专用 GitHub App，仅安装至 `gewill/OpenCCman` 与 `gewill/SwiftyOpenCC`，仓库权限只选 **Contents: read/write、Pull requests: read/write**。不请求 Actions、Workflows、Administration 或自动批准权限。
-4. 在 OpenCCman 设置变量 `OPENCC_SYNC_APP_ID`、secret `OPENCC_SYNC_APP_PRIVATE_KEY`。这把私钥只传给发布 job；每次令牌仅允许写入当前目标仓库，任务结束撤销。App 私钥不进入检测／构建 job。写入另一公开仓库之外的来源与 check 信息用公开只读 API 获取，未扩大令牌权限。
+4. 在 OpenCCman 设置变量 `OPENCC_SYNC_APP_ID`、secret `OPENCC_SYNC_APP_PRIVATE_KEY`。这把私钥只传给发布 job；每次令牌仅允许写入当前目标仓库，任务结束撤销。App 私钥不进入检测／构建 job。公开来源与 check 信息使用当前 job 的只读 `GITHUB_TOKEN` 认证读取；发布步骤以 `GH_READ_TOKEN` 单独传入该读令牌，`GH_TOKEN` 中的 App 写令牌只供变更 API／Git push 使用，未扩大 App 权限。
 5. 给 fork/master、App/build 配置分支保护：要求 PR、相应 CI 成功、禁止 force-push。机器人不加入绕过列表。个人仓库单人维护时不强制另一位 reviewer，以免唯一维护者无法合并自己的人工 PR。
 
 GitHub 定时任务只从默认分支运行；公开仓库 60 天无活动会停用 schedule，定时运行也可能延迟，因此它不是可靠的定时提醒服务。[官方事件说明](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule)
@@ -19,6 +19,8 @@ GitHub 定时任务只从默认分支运行；公开仓库 60 天无活动会停
 需要 Python 3、Git、已登录的 `gh`；准备候选还需要 macOS、Xcode 命令行工具、Swift、CMake，以及 fork 资源脚本声明的构建工具。执行位置任意，脚本配置相对脚本定位。
 
 本地发布通过命令专用 `gh auth git-credential` 使用 `gh` 登录、`GH_TOKEN` 或 `GITHUB_TOKEN`，不改全局 Git 凭证设置。准备进程会移除显式 token 环境变量；本地运行仍可访问开发者原有 Git／钥匙串配置，它不是无凭证沙箱。Actions 的写入私钥和令牌只存在于独立发布 job。
+
+GET 优先使用 `GH_READ_TOKEN`，未设置时复用 `gh` 的现有认证。公开 API 不再匿名请求，避免共享 runner 出口的每小时 60 次匿名限额。`Upstream Coordinator Tests` 会实际用只读 job token 验证两个仓库的 checks API 可读；403／限额错误仍返回退出码 5，不降级为匿名请求或解释为没有 CI。[GitHub API 限额](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)、[公开 Checks API 权限](https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference)
 
 ```sh
 python3 scripts/sync-upstream.py check --stage fork

--- a/scripts/sync-upstream.py
+++ b/scripts/sync-upstream.py
@@ -16,9 +16,7 @@ import re
 import subprocess
 import sys
 import tempfile
-from urllib.parse import quote
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from urllib.parse import quote, urlsplit
 
 SHA = re.compile(r"^[0-9a-f]{40}$")
 TAG = re.compile(r"^ver\.(\d+)\.(\d+)\.(\d+)$")
@@ -36,7 +34,7 @@ def run(args, cwd=None, env=None, code=4):
     result = subprocess.run(args, cwd=cwd, env=env, text=True,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     logged = f"$ {Path(args[0]).name}\n{result.stdout}\n{result.stderr}\n"
-    for key in ("GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"):
+    for key in ("GH_READ_TOKEN", "GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"):
         secret = (env or os.environ).get(key)
         if secret:
             logged = logged.replace(secret, "[REDACTED]")
@@ -68,45 +66,38 @@ def version(tag):
 
 
 class GitHub:
-    def public_api(self, endpoint, paginate=False):
-        """Read public sources without widening a publishing token's scope."""
-        url = "https://api.github.com/" + endpoint
-        pages = []
-        while url:
-            if not url.startswith("https://api.github.com/"):
-                raise SyncError("Unexpected public API pagination host", 5)
-            request = Request(url, headers={"Accept": "application/vnd.github+json",
-                                           "User-Agent": "opencc-upstream-sync"})
-            try:
-                with urlopen(request, timeout=30) as response:
-                    value = json.load(response)
-                    link = response.headers.get("Link", "")
-            except (HTTPError, URLError) as error:
-                raise SyncError(f"Public GitHub read failed: {error}", 5) from error
-            if not paginate:
-                return value
-            pages.extend(value)
-            next_link = re.search(r'<([^>]+)>; rel="next"', link)
-            url = next_link[1] if next_link else None
-        return pages
+    @staticmethod
+    def endpoint(endpoint):
+        # gh accepts complete URLs; only our GitHub repository API paths are
+        # valid here. Pin --hostname too, regardless of a local GH_HOST value.
+        parsed = urlsplit(endpoint)
+        if (parsed.scheme or parsed.netloc or parsed.fragment or "\\" in endpoint
+                or "\r" in endpoint or "\n" in endpoint
+                or not re.match(r"^(repos/[^/?]+/[^/?]+/|repositories/[0-9]+/)", endpoint)
+                or any(part in (".", "..") for part in parsed.path.split("/"))):
+            raise SyncError("Unexpected GitHub API endpoint", 5)
+        return endpoint
 
     def api(self, endpoint, method="GET", body=None, paginate=False):
-        # A publish token is deliberately scoped to only its write destination.
-        # Other public repositories remain readable without granting it access.
-        destination = os.environ.get("OPENCC_SYNC_WRITE_REPOSITORY")
-        if method == "GET" and destination and not endpoint.startswith(f"repos/{destination}/"):
-            return self.public_api(endpoint, paginate)
-        args = ["gh", "api", endpoint, "--method", method]
+        # Public checks remain public, but authentication avoids the shared
+        # runner IP's anonymous API quota. Publishing keeps GET credentials
+        # separate from the App token used by mutations and Git pushes.
+        env = dict(os.environ)
+        if method == "GET" and env.get("GH_READ_TOKEN"):
+            env["GH_TOKEN"] = env["GH_READ_TOKEN"]
+        endpoint = self.endpoint(endpoint)
+        args = ["gh", "api", endpoint, "--hostname", "github.com", "--method", method]
         if paginate:
             args += ["--paginate", "--slurp"]
         if body is None:
-            raw = run(args, code=5)
+            raw = run(args, code=5, env=env)
         else:
-            # gh --input consumes a file, preserving literal text/newlines.
+            # gh --input preserves literal text/newlines; tokens never enter
+            # command arguments or captured `gh auth token` output.
             with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as stream:
                 json.dump(body, stream)
                 stream.flush()
-                raw = run(args + ["--input", stream.name], code=5)
+                raw = run(args + ["--input", stream.name], code=5, env=env)
         result = json.loads(raw) if raw else None
         return [item for page in result for item in page] if paginate else result
 
@@ -137,8 +128,7 @@ class GitHub:
 
     def check_passed(self, repo, commit, name):
         # Latest run of the named check wins; never accept an older green retry.
-        # Public checks need no token; the sync App does not need Checks:read.
-        pages = self.public_api(f"repos/{repo}/commits/{sha(commit)}/check-runs?filter=latest&per_page=100")
+        pages = self.api(f"repos/{repo}/commits/{sha(commit)}/check-runs?filter=latest&per_page=100")
         checks = [c for c in pages["check_runs"] if c["name"] == name
                   and c.get("app", {}).get("slug") == "github-actions"
                   and c.get("head_sha") == commit]
@@ -335,7 +325,7 @@ def validate_candidate(config, data, path):
     # CI injects no write credential here. Strip explicit token variables too;
     # this is not a sandbox for a local developer's keychain/Git configuration.
     clean = {k: v for k, v in os.environ.items() if k not in
-             {"GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"}}
+             {"GH_READ_TOKEN", "GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"}}
     if data["stage"] == "fork":
         run(["python3", cfg["generator"]], cwd=path, env=clean)
         run(["python3", cfg["generator"], "--check"], cwd=path, env=clean)

--- a/tests/test_upstream_sync.py
+++ b/tests/test_upstream_sync.py
@@ -405,10 +405,10 @@ class SyncIntegrationTests(unittest.TestCase):
              "head_sha": commit, "status": "completed", "conclusion": "success", "id": 1},
             {"name": "OpenCC Compatibility", "app": {"slug": "github-actions"},
              "head_sha": commit, "status": "completed", "conclusion": "failure", "id": 2}]}
-        with patch.object(github, "public_api", return_value=checks):
+        with patch.object(github, "api", return_value=checks):
             self.assertFalse(github.check_passed("fixture/repo", commit, "OpenCC Compatibility"))
         checks["check_runs"][1]["head_sha"] = "b" * 40
-        with patch.object(github, "public_api", return_value=checks):
+        with patch.object(github, "api", return_value=checks):
             self.assertTrue(github.check_passed("fixture/repo", commit, "OpenCC Compatibility"))
 
     def test_git_credential_protocol_accepts_github_token_or_persistent_gh_login(self):
@@ -433,13 +433,80 @@ class SyncIntegrationTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("password=" + (token or "fixture-persistent-login"), result.stdout)
 
+    def test_public_get_uses_read_auth_while_post_retains_write_auth(self):
+        binary = self.root / "api-bin"
+        binary.mkdir()
+        fake = binary / "gh"
+        fake.write_text('''#!/usr/bin/env python3
+import json, os, sys
+args = sys.argv[1:]
+assert args[0] == 'api'
+assert args[args.index('--hostname') + 1] == 'github.com'
+method = args[args.index('--method') + 1]
+expected = 'fixture-reader' if method == 'GET' else 'fixture-writer'
+assert os.environ['GH_TOKEN'] == expected
+if '--paginate' in args:
+    assert '--slurp' in args
+    print(json.dumps([[{'page': 1}], [{'page': 2}]]))
+else:
+    if method == 'POST':
+        with open(args[args.index('--input') + 1]) as stream:
+            assert json.load(stream)['body'] == 'literal\\nbody'
+    print(json.dumps({'method': method}))
+''')
+        fake.chmod(0o755)
+        env = {"PATH": str(binary) + os.pathsep + os.environ["PATH"],
+               "GH_READ_TOKEN": "fixture-reader", "GH_TOKEN": "fixture-writer", "GH_HOST": "outside.test"}
+        github = sync.GitHub()
+        with patch.dict(os.environ, env):
+            self.assertEqual(github.api("repos/other/public/check-runs")["method"], "GET")
+            self.assertEqual(github.api("repos/other/public/releases", paginate=True), [{"page": 1}, {"page": 2}])
+            self.assertEqual(github.api("repos/target/public/pulls", "POST", {"body": "literal\nbody"})["method"], "POST")
+
+    def test_authenticated_rate_limit_is_an_error_without_anonymous_fallback(self):
+        binary = self.root / "rate-limit-bin"
+        binary.mkdir()
+        calls = self.root / "api-calls"
+        fake = binary / "gh"
+        fake.write_text('''#!/usr/bin/env python3
+import os, pathlib, sys
+assert os.environ['GH_TOKEN'] == 'fixture-reader'
+with pathlib.Path(os.environ['FIXTURE_CALLS']).open('a') as stream:
+    stream.write('request\\n')
+print('gh: API rate limit exceeded (HTTP 403)', file=sys.stderr)
+raise SystemExit(1)
+''')
+        fake.chmod(0o755)
+        with patch.dict(os.environ, {"PATH": str(binary) + os.pathsep + os.environ["PATH"],
+                                     "GH_READ_TOKEN": "fixture-reader", "FIXTURE_CALLS": str(calls)}):
+            with self.assertRaises(sync.SyncError) as context:
+                sync.GitHub().check_passed("other/public", "a" * 40, "Example Check")
+        self.assertEqual(context.exception.code, 5)
+        self.assertIn("HTTP 403", str(context.exception))
+        self.assertEqual(calls.read_text(), "request\n")
+
+    def test_absolute_or_traversing_api_endpoints_are_rejected_before_gh(self):
+        for endpoint in ("https://outside.test/repos/owner/repo/pulls", "//outside.test/repos/owner/repo/pulls",
+                         "repos/owner/repo/../../outside", "repos/owner/repo/pulls\nInjected"):
+            with patch.object(sync, "run") as process:
+                with self.assertRaises(sync.SyncError):
+                    sync.GitHub().api(endpoint)
+            process.assert_not_called()
+
+    def test_read_token_is_redacted_from_command_logs(self):
+        start = len(sync.RUN_LOG)
+        with patch.dict(os.environ, {"GH_READ_TOKEN": "fixture-reader-secret"}):
+            sync.run(["python3", "-c", "import os; print(os.environ['GH_READ_TOKEN'])"])
+        self.assertNotIn("fixture-reader-secret", "\n".join(sync.RUN_LOG[start:]))
+        self.assertIn("[REDACTED]", "\n".join(sync.RUN_LOG[start:]))
+
     def test_validation_subprocesses_receive_no_tokens(self):
         commands = []
-        with patch.dict(os.environ, {"GH_TOKEN": "fixture-secret", "GITHUB_TOKEN": "fixture-secret"}):
+        with patch.dict(os.environ, {"GH_READ_TOKEN": "fixture-reader", "GH_TOKEN": "fixture-secret", "GITHUB_TOKEN": "fixture-secret"}):
             with patch.object(sync, "run", side_effect=lambda args, **kwargs: commands.append(kwargs["env"])):
                 sync.validate_candidate(self.config, {"stage": "fork"}, self.root)
         self.assertEqual(len(commands), 3)
-        self.assertTrue(all("GH_TOKEN" not in e and "GITHUB_TOKEN" not in e for e in commands))
+        self.assertTrue(all("GH_READ_TOKEN" not in e and "GH_TOKEN" not in e and "GITHUB_TOKEN" not in e for e in commands))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
首次实际同步在 macOS `prepare` 阶段读取公开 checks API 时命中匿名限额并退出 5，尚未开始构建。公开 GET 现在复用 `gh` 认证，发布步骤单独传入只读 `GH_READ_TOKEN`；App 写令牌仍只负责变更 API 和 Git push，不增加 GitHub App 权限。

请求固定至 `github.com` 并拒绝绝对／跳转 endpoint；读令牌加入日志脱敏及候选执行前清理。403 仍明确失败，不退回匿名请求或当作缺少 CI。

验证：27 项隔离 Git／假 gh 集成测试、YAML 与 diff 检查通过，本地真实 App 检测返回预期候选。新增真实 CI smoke，以 job 的 `contents: read` GITHUB_TOKEN 读取两个公开仓库的 checks API，验证跨仓库权限行为；PR 事件不会运行检测、构建或发布同步候选。

失败证据：[首次手动运行](https://github.com/gewill/OpenCCman/actions/runs/34682439034)。
