### PR TITLE
docs: 整理两仓库同步指南并加入 README 入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ An OpenCC UI for iOS、iPadOS、macOS by SwiftUI with ❤️
 
 [![Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917](./assets/Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg)](https://apps.apple.com/app/id6474449401)
 
+## Upstream sync
+
+Application development lives on [`build`](https://github.com/gewill/OpenCCman/tree/build); `main` hosts the upstream coordinator. It checks wrapper commits and stable OpenCC releases every Monday at 09:17 (UTC+8), opens a SwiftyOpenCC PR first, then an app revision-update PR after the fork is merged and validated. Maintainers review and merge each PR.
+
+See the [upstream sync guide](docs/upstream-sync.md) for repository responsibilities, local commands, CI credentials, failure recovery and rollback. The [Sync OpenCC workflow](https://github.com/gewill/OpenCCman/actions/workflows/sync-opencc.yml) also supports manual runs.
+
 ## License
 
 MIT License

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -1,8 +1,38 @@
 # OpenCC 上游同步
 
-协调器放在 **OpenCCman/main**，应用更新 PR 始终指向 **OpenCCman/build**；不需要把 main 的旧应用代码合入 build。每周一 UTC 01:17（台北 09:17）检测，也可手动运行 `Sync OpenCC`。它只开 PR，合并由维护者决定。
+本指南是两个仓库共用的协调器操作入口。引擎源码、资源生成及兼容性要求见 [SwiftyOpenCC 维护指南](https://github.com/gewill/SwiftyOpenCC/blob/master/docs/upstream-sync.md)。
 
-## 首次启用
+## 仓库职责与合并顺序
+
+| 位置 | 职责 | 更新方式 |
+| --- | --- | --- |
+| `ddddxxx/SwiftyOpenCC/master` | Swift wrapper 上游 | 合并尚未包含的上游提交，保留 fork 补丁 |
+| `BYVoid/OpenCC` 正式 Release | OpenCC 核心与词库来源 | 同步锁定版本的源码、配置、生成词典和测试语料 |
+| [SwiftyOpenCC/master](https://github.com/gewill/SwiftyOpenCC/tree/master) | 兼容桥接、资源与引擎 CI | 第一层 PR，使用 merge commit 合并 |
+| [OpenCCman/main](https://github.com/gewill/OpenCCman/tree/main) | 协调器、配置、定时工作流 | 自动化改动单独向 main 提 PR |
+| [OpenCCman/build](https://github.com/gewill/OpenCCman/tree/build) | 应用代码、精确依赖与应用 CI | 第二层 PR，采用已合并且验证成功的 fork SHA |
+
+```text
+ddddxxx/SwiftyOpenCC 提交 + BYVoid/OpenCC 正式版
+  → SwiftyOpenCC/master 同步 PR
+  → 维护者以 merge commit 合并，等待合并后 OpenCC Compatibility 成功
+  → OpenCCman/build 精确 revision PR
+  → 维护者审查 App Regression 后合并
+```
+
+协调器只开 PR，不自动合并；所有候选都在临时 checkout 准备，不切换或重置开发者工作区。不要为了同步依赖把 main 的旧应用代码合入 build。
+
+## 日常操作
+
+[Sync OpenCC](https://github.com/gewill/OpenCCman/actions/workflows/sync-opencc.yml) 每周一 UTC 01:17（台北 09:17）检查，也可在 Actions 页面选择 **Run workflow → main**。每次只推进一层；fork 仍待审或 CI 未通过时，应用层等待。fork 合并且 CI 通过后，重新运行或等待下一次周检。
+
+查看运行摘要中的 `fork`／`app` 状态和 PR 链接；失败时下载 `detection`／`candidate` artifact（保留 7 天），先看 `report.md`、`failure.json` 和 `prepare.log`。若失败发生在准备之前，以 job 日志和已生成的检测 JSON 为准。
+
+本地从 **OpenCCman/main 的 checkout** 执行下节命令；SwiftyOpenCC 不另设定时发布器。分支、来源和检查名以 [协调器配置](../scripts/upstream-sync.json) 为准，运行步骤以 [工作流](../.github/workflows/sync-opencc.yml) 为准。
+
+## 初次配置与恢复
+
+以下用于新环境配置或恢复现有集成；日常同步不需要重新创建 App 或私钥。
 
 1. 先人工合并 SwiftyOpenCC 的官方 `SimpleConverter`／JSON 配置迁移，使 fork/master 包含 `scripts/update-opencc-resources.py`、`Sources/OpenCC/Resources/manifest.json`（`schemaVersion=1`、`bridgeVersion=1`）与 `OpenCC Compatibility` CI。旧桥接不能仅替换子模块来升级。
 2. 让协调器进入 OpenCCman/main；让应用回归脚本与 `App Regression` CI 进入 build。两个 CI 的 **job 名称**也必须分别为 `OpenCC Compatibility`、`App Regression`。fork CI 必须测试 `push: master`，因为应用推广检查的是合并后的精确 SHA。
@@ -26,6 +56,10 @@ GET 优先使用 `GH_READ_TOKEN`，未设置时复用 `gh` 的现有认证。公
 python3 scripts/sync-upstream.py check --stage fork
 python3 scripts/sync-upstream.py prepare --stage fork
 python3 scripts/sync-upstream.py pr --stage fork
+
+# fork 合并且合并后的 CI 成功后，再处理应用层
+python3 scripts/sync-upstream.py check --stage app
+python3 scripts/sync-upstream.py pr --stage app
 ```
 
 - `check` 读取远端状态；`prepare` 在独立临时 checkout 生成、测试候选，不 push。未传 `--output` 时创建持久临时目录，JSON 的 `artifact_directory` 返回路径。
@@ -33,11 +67,11 @@ python3 scripts/sync-upstream.py pr --stage fork
 - 一次只推进一层。fork PR 人工 **Create a merge commit** 合入 master 后，再手动运行 workflow，或等下一次周检，才生成 App PR。也可把上述命令的 `--stage fork` 换为 `--stage app`。
 - App 只采用 fork/master 已合入且精确 SHA 上 `OpenCC Compatibility` 成功的版本；App/build 当前精确 SHA 也必须已有成功的 `App Regression`，发布前再核对两项。修改工程 requirement 为 revision，并更新 `Package.resolved` 中该 pin。执行 `xcodebuild -resolvePackageDependencies -skipPackageUpdates` 校验依赖解析，允许 Xcode 管理 `originHash`，但其他 pin／锁文件字段有任何变化立即失败，不提交。
 
-本机真实 build 分支临时 checkout 已验证从 branch 改为相同 revision 的解析路径：解析成功、其余 14 个 pin 未变、没有 Xcode Build。该证据覆盖解析方式，不代表未来升级一定兼容。
+应用层按 fork/master 的完整提交 SHA 判断更新，不按引擎版本号或文件类型过滤。因此 fork 上仅文档变更的合并，待 CI 通过后也可能产生新的应用 revision PR；这是当前实现的行为。
 
 ## 同步规则与产物
 
-`scripts/upstream-sync.json` 定义两个目标、来源、检查名和回滚忽略清单。OpenCC 只选择公开正式 Release 中最大的 `ver.X.Y.Z`，排除 draft／prerelease；锁完整 SHA，拒绝已接纳 tag 改指向、降级和主版本自动跨越。wrapper 保持跟踪 `ddddxxx/SwiftyOpenCC/master`，保留现 fork 的本地修复。若 wrapper 涉及 workflow 改动，停止并交人工合并，不给机器人 `Workflows:write`。[Release API](https://docs.github.com/en/rest/releases/releases)、[fork 同步](https://docs.github.com/en/pull-requests/how-tos/work-with-forks/syncing-a-fork)
+[scripts/upstream-sync.json](../scripts/upstream-sync.json) 定义两个目标、来源、检查名和回滚忽略清单。OpenCC 只选择公开正式 Release 中最大的 `ver.X.Y.Z`，排除 draft／prerelease；锁完整 SHA，拒绝已接纳 tag 改指向、降级和主版本自动跨越。wrapper 保持跟踪 `ddddxxx/SwiftyOpenCC/master`，保留现 fork 的本地修复。若 wrapper 涉及 workflow 改动，停止并交人工合并，不给机器人 `Workflows:write`。[Release API](https://docs.github.com/en/rest/releases/releases)、[fork 同步](https://docs.github.com/en/pull-requests/how-tos/work-with-forks/syncing-a-fork)
 
 每层最多一条待审 PR。候选标识由来源 SHA 确定，分支固定为 `codex/sync-fork-<id>` 或 `codex/sync-app-<id>`。同候选重试复用 PR；人工关闭但未合并的候选不自动重开；另一候选到达时有旧 PR 待审则等待。出现人工修改、远端 base 变化、合并冲突或非目标依赖漂移时停止，不覆盖或 force-push。
 
@@ -48,6 +82,17 @@ python3 scripts/sync-upstream.py pr --stage fork
 stdout 只输出一条 JSON；详细日志在 stderr／产物内。`status` 为 `noop`、`changed`、`waiting`、`blocked`、`error`。退出码：`0` 正常（包括无变化和等待），`2` 参数／迁移前置条件，`3` 冲突／策略阻断，`4` 验证失败，`5` 网络／认证失败。网络失败不解释为“没有更新”。
 
 无变化只用 Ubuntu；有候选才使用一个固定 macos-15 job。fork 执行资源生成、`--check`、`swift test`，App 执行锁定解析与 core／quota／pasteboard 回归；不启动模拟器或完整 App build。两仓库目前公开，标准 GitHub-hosted runner 免费，仍限制超时和并发以节省等待。[计费说明](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
+
+## 常见状态与恢复
+
+| 状态或问题 | 处理方式 |
+| --- | --- |
+| `noop` | 已同步，或候选已被配置忽略；查看 `reason` 区分 |
+| `waiting` | 查看待审 PR 或缺失的精确 SHA 检查；等待解决后再运行 |
+| 冲突、上游 workflow 改动、主版本升级、移动 tag | 审查来源与冲突路径，必要时单独做兼容迁移 PR；不要强制覆盖 |
+| 资源生成、转换回归或依赖解析失败 | 查看候选日志并修复；不能跳过验证发布 |
+| 403／认证／限额错误 | 查看失败 job 使用的是只读令牌还是发布 App 令牌，核对安装范围、变量与 secret；恢复后重试 |
+| base 或候选分支发生变化 | 重新准备；存在人工改动时先审查，不覆盖旧分支 |
 
 ## 回滚与维护
 
@@ -60,3 +105,11 @@ python3 -m unittest discover -s tests -p 'test_*.py'
 ```
 
 覆盖正常候选、PR 重试／POST 不确定结果、人工拒绝、同名外部 fork、冲突、移动 tag、降级／主版本、base 并发变化、bundle 篡改、测试失败产物、来源门禁、非目标 pin 漂移及验证进程无 token。测试只推送临时本地 fixture 仓库，不访问真实写入 API。
+
+## 首次运行记录（2026-09-12）
+
+首次接通时修复了共享 runner 匿名 API 限额，以及 SwiftPM 从 Git revision 读取包清单时无法访问相邻资源文件的问题。当前流程使用认证读取；引擎清单不再在求值时读取资源 JSON。
+
+- [协调器准备与发布成功](https://github.com/gewill/OpenCCman/actions/runs/34683913795)，通过 GitHub App 创建 [应用依赖 PR #5](https://github.com/gewill/OpenCCman/pull/5)，PR CI 自动启动。
+- PR #5 将应用固定到已通过 CI 的 fork `eacb73dcb28c26e7cc5d8d9cb405e88fa2d59b13`（OpenCC 1.4.2），其余 14 个依赖保持不变；[合并后应用 CI](https://github.com/gewill/OpenCCman/actions/runs/34684262879) 成功。
+- 当时两层 `check` 均返回 `noop`。以上是该次运行证据；以后升级仍须通过各自候选的检查，当前版本以工程锁文件及引擎 manifest 为准。


### PR DESCRIPTION
共用同步指南缺少清晰的仓库职责与日常操作入口，README 也未引用已有说明。本 PR 将 main/build/master 的分工、两层 PR 顺序、失败恢复与首次成功运行证据整理到同一指南，并从默认分支 README 链接。

Log：
- 实现：补充职责表、流程图、手动运行入口、两层 CLI、状态恢复表与跨仓库引用；配置/权限细节保留在共用指南。
- 事实核对：定时为周一 UTC 01:17，artifact 保留 7 天，应用按 fork 完整 SHA 推广；明确文档提交也可能带来新依赖候选。
- 验证：5 份 Markdown、23 个相对及跨仓库目标通过；脚本 --help、配置、workflow、manifest 对照核验；git diff --check 通过。
- 范围：仅 README 与 docs，未修改自动化或应用代码；本地未运行 Xcode Build 或模拟器。现有 workflow 的 PR paths 不包含文档，本 PR 不触发协调器 CI。

配套引擎指南：https://github.com/gewill/SwiftyOpenCC/pull/3 。该 PR 合并后，指向 master 新指南的链接生效；应用 build 分支另以 README PR 引用 main 的同一份指南，不复制协调器。
