### PR TITLE
docs: 在应用 README 引用同步维护指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ bash scripts/check-pasteboard.sh
 
 Core checks compile the actual app model/services with the dependencies pinned in `Package.resolved`. All preferences and pasteboards used by these checks are isolated from the running app. See [1.3 validation](docs/version-1.3-validation.md) for coverage and remaining release checks.
 
+## Upstream sync
+
+The coordinator lives on [`main`](https://github.com/gewill/OpenCCman/tree/main), while application updates target `build`. It proposes a SwiftyOpenCC PR first, then pins the merged, validated fork revision in an app PR. Maintainers review and merge each PR; all other dependencies remain locked.
+
+See the shared [upstream sync guide](https://github.com/gewill/OpenCCman/blob/main/docs/upstream-sync.md) for the Monday 09:17 (UTC+8) schedule, manual commands, CI setup and rollback. Engine-specific work is covered by the [SwiftyOpenCC maintenance guide](https://github.com/gewill/SwiftyOpenCC/blob/master/docs/upstream-sync.md).
+
 ## Thanks
 
 1. [BYVoid](https://github.com/BYVoid)‘s original SDK [OpenCC](https://github.com/BYVoid/OpenCC) 


### PR DESCRIPTION
应用开发位于 build，但共用同步指南位于 main。本 PR 在应用 README 增加入口，说明协调器位置、两层 PR、精确依赖与人工合并规则，避免在 build 复制维护文档。

Log：
- 实现：链接 main 的共用同步指南与 SwiftyOpenCC 的引擎维护指南，标注每周一 09:17（UTC+8）检查。
- 验证：README 目标与两个配套文档分支核对通过；git diff --check 通过；仅 README 增加 6 行，未改依赖或应用代码。
- 本地未运行 Xcode Build 或模拟器；现有 App Regression 按 PR 自动运行。

配套文档（合并后新指南链接生效）：
- https://github.com/gewill/SwiftyOpenCC/pull/3
- https://github.com/gewill/OpenCCman/pull/6
