### PR TITLE
ci: require official CLI evidence and exercise sync rollback

### DIFF
--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -77,11 +77,11 @@ python3 scripts/sync-upstream.py pr --stage app
 
 相同来源与 base 的重新准备使用固定提交元数据，因此 push 成功、PR 创建失败后可以直接重跑并恢复。若在这两步之间 base 已前进，新候选与遗留分支必然不同，自动化会明确停止：先审查报告中的旧分支，确认没有 PR 或人工修改后由维护者删除该孤立分支，再重新运行；不能用 force-push 跳过这个检查。
 
-成功的 `prepare` 输出 `candidate.json`、`candidate.bundle`、`diff.patch`、`report.md`、`prepare.log`。发布再次核对 base、来源 SHA、bundle checksum 和变更范围，并从 bundle 推送经过验证的那个 commit。失败时保留 `failure.json`、报告、命令日志和可获得的 diff，随后删除隔离 checkout；失败候选不能发布。
+成功的 `prepare` 输出 `candidate.json`、`candidate.bundle`、`diff.patch`、`report.md`、`prepare.log`；fork 还保留 `official-cli-report.json`。发布再次核对 base、来源 SHA、bundle checksum 和变更范围，并从 bundle 推送经过验证的那个 commit。失败时保留 `failure.json`、报告、命令日志和可获得的 diff，随后删除隔离 checkout；失败候选不能发布。
 
 stdout 只输出一条 JSON；详细日志在 stderr／产物内。`status` 为 `noop`、`changed`、`waiting`、`blocked`、`error`。退出码：`0` 正常（包括无变化和等待），`2` 参数／迁移前置条件，`3` 冲突／策略阻断，`4` 验证失败，`5` 网络／认证失败。网络失败不解释为“没有更新”。
 
-无变化只用 Ubuntu；有候选才使用一个固定 macos-15 job。fork 执行资源生成、`--check`、`swift test`，App 执行锁定解析与 core／quota／pasteboard 回归；不启动模拟器或完整 App build。两仓库目前公开，标准 GitHub-hosted runner 免费，仍限制超时和并发以节省等待。[计费说明](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
+无变化只用 Ubuntu；有候选才使用一个固定 macos-15 job。fork 执行锁定 CMake 的资源生成、`--check`、`swift test` 和同版本官方 CLI 逐字节对照，App 执行锁定解析与 core／quota／pasteboard 回归；不启动模拟器或完整 App build。两仓库目前公开，标准 GitHub-hosted runner 免费，仍限制超时和并发以节省等待。[计费说明](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
 
 ## 常见状态与恢复
 
@@ -113,3 +113,15 @@ python3 -m unittest discover -s tests -p 'test_*.py'
 - [协调器准备与发布成功](https://github.com/gewill/OpenCCman/actions/runs/34683913795)，通过 GitHub App 创建 [应用依赖 PR #5](https://github.com/gewill/OpenCCman/pull/5)，PR CI 自动启动。
 - PR #5 将应用固定到已通过 CI 的 fork `eacb73dcb28c26e7cc5d8d9cb405e88fa2d59b13`（OpenCC 1.4.2），其余 14 个依赖保持不变；[合并后应用 CI](https://github.com/gewill/OpenCCman/actions/runs/34684262879) 成功。
 - 当时两层 `check` 均返回 `noop`。以上是该次运行证据；以后升级仍须通过各自候选的检查，当前版本以工程锁文件及引擎 manifest 为准。
+
+## 1.3 验证补强
+
+fork 候选现在必须执行 `scripts/check-official-cli.py`，且报告为通过、核心 tag/SHA 与候选一致。先合入 [SwiftyOpenCC #4](https://github.com/gewill/SwiftyOpenCC/pull/4) 的工具锁定和 CLI 验证改动，再合入本协调器更新；缺少脚本或报告时按验证失败停止，不跳过检查。
+
+CMake 的版本与官方下载校验和由 fork 的 `BuildTools/cmake.json` 锁定；生成器记录参数、编译器及主机信息。官方 CLI 使用与 wrapper 相同的词典加载选项，兼容模式和 NUL workaround 仍单独验证。生成工具和引擎接口细节见引擎维护指南。
+
+成功与失败时可获得的 CLI JSON 都保存在 candidate artifact。状态或来源不符、没有报告均不能发布；29 个协调器 fixture 测试包含缺失报告、来源不符以及显式 token 不进入新增验证命令。CMake/CLI 补强不表示应用最终分发、购买或旧系统真机已验收。
+
+隔离演练还使用临时 Git 仓库执行 fork merge commit → app 推广 → 新提交恢复旧 pin → revert 整个 fork merge，验证祖先关系保留、忽略清单阻止旧候选以及新来源仍可继续。生成器/编译器在该流程测试中使用替身；这不是生产仓库回滚或未来 OpenCC 版本的真实构建记录。
+
+应用正式打包使用 Xcode Cloud；分支名以 `build` 开头即符合现有自动触发规则，因此应用 PR 合入 `build` 会触发 iOS/macOS 归档。GitHub 回归与候选检查不等于云端分发通过。App ID、workflow 和构建记录规则见 [应用分支的 Xcode Cloud 指南](https://github.com/gewill/OpenCCman/blob/build/docs/XCODE_CLOUD.md)；该指南随应用收尾 PR 合入后生效。

--- a/scripts/sync-upstream.py
+++ b/scripts/sync-upstream.py
@@ -13,6 +13,7 @@ import json
 import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -330,6 +331,7 @@ def validate_candidate(config, data, path):
         run(["python3", cfg["generator"]], cwd=path, env=clean)
         run(["python3", cfg["generator"], "--check"], cwd=path, env=clean)
         run(["swift", "test"], cwd=path, env=clean)
+        run(["python3", "scripts/check-official-cli.py"], cwd=path, env=clean)
     else:
         run(["xcodebuild", "-resolvePackageDependencies", "-project", cfg["project"],
              "-scheme", cfg["scheme"], "-skipPackageUpdates"], cwd=path, env=clean)
@@ -363,6 +365,9 @@ def candidate_workspace(output, data):
         try:
             yield path
         except Exception as error:
+            cli_report = path / ".build/official-cli-report.json"
+            if cli_report.is_file():
+                shutil.copyfile(cli_report, output / "official-cli-report.json")
             failure = {**data, "status": "blocked", "reason": str(error),
                        "artifact_directory": str(output), **getattr(error, "details", {})}
             (output / "failure.json").write_text(json.dumps(failure, ensure_ascii=False, indent=2) + "\n")
@@ -422,13 +427,24 @@ def prepare(config, stage, github, output, expected=None):
             project = path / cfg["project"] / "project.pbxproj"
             project.write_text(pin_project(project.read_text(), data["fork_sha"]))
         validate_candidate(config, data, path)
+        if stage == "fork":
+            cli_report = path / ".build/official-cli-report.json"
+            if not cli_report.is_file():
+                raise SyncError("Official CLI report missing; first merge the fork validation tools", 4)
+            try:
+                comparison = json.loads(cli_report.read_text())
+            except (ValueError, OSError) as error:
+                raise SyncError("Official CLI report is unreadable or invalid JSON", 4) from error
+            if not isinstance(comparison, dict) or comparison.get("status") != "passed" or comparison.get("opencc") != {"tag": data["core_tag"], "revision": data["core_sha"]}:
+                raise SyncError("Official CLI validation does not match the selected core", 4)
+            shutil.copyfile(cli_report, output / "official-cli-report.json")
         git(path, "add", "--all")
         message = (f"chore: sync OpenCC {stage} ({data['candidate']})\n\n"
                    "Log:\n需求描述: 同步已核验的 OpenCC 依赖。\n实现思路: 固定来源 SHA，生成并校验资源，经人工 PR 合并。")
         core_time = int(git(path / cfg["corePath"], "show", "-s", "--format=%ct", data["core_sha"])) if stage == "fork" else 0
         git(path, "commit", "-m", message, env=commit_environment(path, "HEAD", minimum=core_time))
         data["head_sha"] = sha(git(path, "rev-parse", "HEAD"))
-        data["checks"] = (["resource generation", "manifest --check", "swift test"] if stage == "fork"
+        data["checks"] = (["pinned resource generation", "manifest --check", "swift test", "official CLI byte comparison"] if stage == "fork"
                           else ["locked package resolution", "core", "quota", "pasteboard"])
         verify_diff(config, data, path)
         git(path, "bundle", "create", str(output / "candidate.bundle"), f"refs/heads/{data['branch']}", f"^{data['base_sha']}")

--- a/tests/test_upstream_sync.py
+++ b/tests/test_upstream_sync.py
@@ -165,6 +165,11 @@ class SyncIntegrationTests(unittest.TestCase):
             value = json.loads(manifest.read_text())
             value["opencc"] = {"tag": data["core_tag"], "revision": data["core_sha"]}
             manifest.write_text(json.dumps(value))
+            cli_report = path / ".build/official-cli-report.json"
+            cli_report.parent.mkdir(exist_ok=True)
+            cli_report.write_text(json.dumps({"status": "passed", "opencc": value["opencc"]}))
+            # Production .build is ignored; keep fixture artifacts untracked too.
+            (path / ".git/info/exclude").write_text(".build/\n")
         else:
             lock = path / config["app"]["resolved"]
             value = json.loads(lock.read_text())
@@ -500,12 +505,80 @@ raise SystemExit(1)
         self.assertNotIn("fixture-reader-secret", "\n".join(sync.RUN_LOG[start:]))
         self.assertIn("[REDACTED]", "\n".join(sync.RUN_LOG[start:]))
 
+    def test_merge_promotion_and_rollback_ignore_candidates_without_rewriting_history(self):
+        fork_data, fork_artifact = self.prepare("fork")
+        sync.publish(self.config, "fork", self.github, fork_artifact)
+        command(self.fork, "merge", "--no-ff", fork_data["branch"], "-m", "Review and merge fork PR")
+        accepted = command(self.fork, "rev-parse", "HEAD")
+        fork_pr = self.github.prs[self.config["fork"]["repository"]][0]
+        fork_pr.update(state="closed", merged_at="fixture-merged")
+        self.assertEqual(sync.discover(self.config, "fork", self.github)["status"], "noop")
+        app_data, app_artifact = self.prepare("app")
+        sync.publish(self.config, "app", self.github, app_artifact)
+        command(self.app, "merge", "--no-ff", app_data["branch"], "-m", "Review and merge app PR")
+        promoted = command(self.app, "rev-parse", "HEAD")
+        app_pr = self.github.prs[self.config["app"]["repository"]][0]
+        app_pr.update(state="closed", merged_at="fixture-merged")
+        self.assertEqual(sync.discover(self.config, "app", self.github)["status"], "noop")
+
+        # Roll back through a new commit, preserving the promoted history.
+        lock = self.app / self.config["app"]["resolved"]
+        pins = json.loads(lock.read_text())
+        sync.get_pin(pins)["state"] = {"revision": self.old_fork}
+        lock.write_text(json.dumps(pins))
+        project = self.app / self.config["app"]["project"] / "project.pbxproj"
+        project.write_text(sync.pin_project(project.read_text(), self.old_fork))
+        command(self.app, "add", ".")
+        command(self.app, "commit", "-m", "Restore prior app revision")
+        self.config["ignoredCandidates"]["app"].append(app_data["candidate"])
+        ignored = sync.discover(self.config, "app", self.github)
+        self.assertEqual(ignored["status"], "noop")
+        self.assertIn("ignored", ignored["reason"])
+        command(self.app, "merge-base", "--is-ancestor", promoted, "HEAD")
+
+        # Revert the complete fork merge without deleting its ancestry.
+        command(self.fork, "revert", "--mainline", "1", "--no-edit", accepted)
+        command(self.fork, "merge-base", "--is-ancestor", accepted, "HEAD")
+        manifest = json.loads((self.fork / self.config["fork"]["manifest"]).read_text())
+        self.assertEqual(manifest["opencc"]["revision"], self.old_core)
+        self.config["ignoredCandidates"]["fork"].append(fork_data["candidate"])
+        ignored = sync.discover(self.config, "fork", self.github)
+        self.assertEqual(ignored["status"], "noop")
+        self.assertIn("ignored", ignored["reason"])
+
+        # A genuinely new source remains eligible; the old rejection is scoped.
+        upstream = self.github.repo(self.config["fork"]["upstreamRepository"])
+        self.write_commit(upstream, "wrapper.swift", "new reviewed upstream change\n")
+        self.assertEqual(sync.discover(self.config, "fork", self.github)["status"], "changed")
+
+    def test_fork_requires_cli_report_for_selected_core(self):
+        for state in ("missing", "wrong-source", "failed", "malformed", "list"):
+            output = self.root / ("cli-failure-" + state)
+            def validator(config, data, path):
+                self.validator(config, data, path)
+                report = path / ".build/official-cli-report.json"
+                if state == "missing":
+                    report.unlink()
+                elif state == "wrong-source":
+                    report.write_text(json.dumps({"status": "passed", "opencc": {"tag": "ver.1.4.1", "revision": self.old_core}}))
+                elif state == "failed":
+                    report.write_text(json.dumps({"status": "failed", "opencc": {"tag": data["core_tag"], "revision": data["core_sha"]}}))
+                else:
+                    report.write_text("[]" if state == "list" else "{broken")
+            with patch.object(sync, "validate_candidate", side_effect=validator):
+                with self.assertRaises(sync.SyncError) as failure:
+                    sync.prepare(self.config, "fork", self.github, output)
+            self.assertEqual(failure.exception.code, 4)
+            self.assertTrue((output / "failure.json").exists())
+            self.assertFalse((output / "candidate.bundle").exists())
+            self.assertEqual((output / "official-cli-report.json").exists(), state != "missing")
+
     def test_validation_subprocesses_receive_no_tokens(self):
         commands = []
         with patch.dict(os.environ, {"GH_READ_TOKEN": "fixture-reader", "GH_TOKEN": "fixture-secret", "GITHUB_TOKEN": "fixture-secret"}):
             with patch.object(sync, "run", side_effect=lambda args, **kwargs: commands.append(kwargs["env"])):
                 sync.validate_candidate(self.config, {"stage": "fork"}, self.root)
-        self.assertEqual(len(commands), 3)
+        self.assertEqual(len(commands), 4)
         self.assertTrue(all("GH_READ_TOKEN" not in e and "GH_TOKEN" not in e and "GITHUB_TOKEN" not in e for e in commands))
 
 


### PR DESCRIPTION
fork 候选原先没有执行同版本官方 CLI 对照，回滚也缺少完整 Git 流程演练。本次将 CLI 检查纳入隔离验证，要求通过报告与候选核心 tag/SHA 一致，并保留成功或失败 JSON。

依赖：https://github.com/gewill/SwiftyOpenCC/pull/4 必须先合并；缺少新脚本/报告会停止 fork 准备。应用正式归档继续由 build 前缀触发 Xcode Cloud。

Log：
- 实现：新增无显式 token 的 CLI 验证命令、报告门禁及 artifact；复用原有人工两层 PR 发布流程。
- 验证：29 个测试通过（43.574s），包括报告缺失/损坏/失败/来源不符，临时 Git 仓库 merge、推广、恢复旧 pin、revert fork merge、忽略旧候选、新来源继续和祖先关系检查。
- 边界：Git 操作真实执行，生成/编译在流程 fixture 中为替身；没有回滚生产仓库，也没有把未来核心正式升级写成已实跑。
- 记录：docs/upstream-sync.md 更新验证、依赖顺序和 Xcode Cloud 文档入口。
